### PR TITLE
Augment test infrastructure, part deux

### DIFF
--- a/pycds/util.py
+++ b/pycds/util.py
@@ -264,3 +264,32 @@ def create_test_data_from_reflection(read_engine, write_engine):
             wSession.add(new_hist)
 
     wSession.commit()
+
+
+def generic_sesh(sesh, sa_classes, sa_objects):
+    '''All session fixtures follow a common pattern, abstracted in this generator function.
+    To use the generator correctly, i.e., so that the teardown after the yield is also performed,
+    a fixture must first yield the result of next(g), then call next(g) again. This can be done two ways:
+
+      gs = generic_sesh(...)
+      yield next(gs)
+      next(gs)
+
+    or, slightly shorter:
+
+      for sesh in generic_sesh(...):
+          yield sesh
+
+    The shorter method is used throughout.
+    '''
+    if not isinstance(sa_objects[0], list):
+        sa_objects = [sa_objects]
+    for sao in sa_objects:
+        sesh.add_all(sao)
+        sesh.flush()
+    yield sesh
+    if not isinstance(sa_classes, list):
+        sa_classes = [sa_classes]
+    for sa_class in sa_classes:
+        sesh.query(sa_class).delete()
+        sesh.flush()


### PR DESCRIPTION
Add module-scoped fixtures for blank postgis session and empty database session.
Add generic session fixture for setting up and tearing down test database contents.