### PR TITLE
Bump to version 2.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
-__version__ = (2, 1, 0)
+__version__ = (2, 1, 1)
 
 
 class PyTest(TestCommand):


### PR DESCRIPTION
Already published a 2.1.0 -- oops. PyPI doesn't let you replace versions, you must use a new version #.