### PR TITLE
Fixes for production use of manage-views

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 3.4
   - 3.5
 addons:
-  postgresql: "9.3"
+  postgresql: "9.1"
 install:
   - pip install -U pip
   - pip install -i https://pypi.pacificclimate.org/simple/ -r requirements.txt -r test_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 3.4
   - 3.5
 addons:
-  postgresql: "9.1"
+  postgresql: "9.3"
 install:
   - pip install -U pip
   - pip install -i https://pypi.pacificclimate.org/simple/ -r requirements.txt -r test_requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Some testing data was sourced from a production database. The steps to produce t
 1. As database superuser, run CREATE SCHEMA subset AUTHRIZATION <username>;
 2. As that user, run ``psql -h <db_host> -f create_crmp_subset.sql crmp. This insert a selection of data into the ``subset`` schema.
 3. Then, ``pg_dump -h <db_host> -d crmp --schema=subset --data-only --no-owner --no-privileges --no-tablespaces --column-inserts -f pycds/data/crmp_subset_data.sql``
-4. Edit this file removing the ``SET search_path...`` line, and re-ordering the data inserts to respect foreign key constraints. Default sort is alphabetical and the only changes that should need to be made are ordering meta_network, meta_station, and meta_history first and leaving the remaining inserts ordered as is.
+4. Edit this file change the ``SET search_path...`` line to ``SET search_path = crmp``, and re-ordering the data inserts to respect foreign key constraints. Default sort is alphabetical and the only changes that should need to be made are ordering meta_network, meta_station, and meta_history first and leaving the remaining inserts ordered as is.
 
 BDD Test Framework ``(pytest-describe``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pycds/__init__.py
+++ b/pycds/__init__.py
@@ -17,7 +17,7 @@ from sqlalchemy.schema import DDL, UniqueConstraint
 from geoalchemy2 import Geometry
 
 
-Base = declarative_base(metadata=MetaData(schema='crmp'))  # TODO: refactor metadata
+Base = declarative_base(metadata=MetaData(schema='crmp'))
 metadata = Base.metadata
 
 
@@ -365,7 +365,7 @@ class ObsWithFlags(Base):
 sqlalchemy.event.listen(
     metadata, 'before_create',
     DDL('''
-        CREATE OR REPLACE FUNCTION DaysInMonth(date) RETURNS double precision AS
+        CREATE OR REPLACE FUNCTION crmp.DaysInMonth(date) RETURNS double precision AS
         $$
             SELECT EXTRACT(DAY FROM CAST(date_trunc('month', $1) + interval '1 month' - interval '1 day'
             as timestamp));

--- a/pycds/__init__.py
+++ b/pycds/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
 ]
 
 import sqlalchemy
+from sqlalchemy import MetaData
 from sqlalchemy import Table, Column, Integer, BigInteger, Float, String, Date
 from sqlalchemy import DateTime, Boolean, ForeignKey, Numeric, Interval
 from sqlalchemy.ext.declarative import declarative_base, DeferredReflection
@@ -16,7 +17,7 @@ from sqlalchemy.schema import DDL, UniqueConstraint
 from geoalchemy2 import Geometry
 
 
-Base = declarative_base()
+Base = declarative_base(metadata=MetaData(schema='crmp'))  # TODO: refactor metadata
 metadata = Base.metadata
 
 

--- a/pycds/__init__.py
+++ b/pycds/__init__.py
@@ -361,14 +361,3 @@ class ObsWithFlags(Base):
     flag_name = Column(String)
     description = Column(String)
     flag_value = Column(String)
-
-sqlalchemy.event.listen(
-    metadata, 'before_create',
-    DDL('''
-        CREATE OR REPLACE FUNCTION crmp.DaysInMonth(date) RETURNS double precision AS
-        $$
-            SELECT EXTRACT(DAY FROM CAST(date_trunc('month', $1) + interval '1 month' - interval '1 day'
-            as timestamp));
-        $$ LANGUAGE sql;
-    ''')
-)

--- a/pycds/data/crmp_subset_data.sql
+++ b/pycds/data/crmp_subset_data.sql
@@ -9,6 +9,9 @@ SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 
+
+SET search_path = crmp;
+
 --
 -- Data for Name: meta_network; Type: TABLE DATA; Schema: subset; Owner: -
 --

--- a/pycds/manage_views.py
+++ b/pycds/manage_views.py
@@ -2,12 +2,10 @@ import logging
 
 from pycds.materialized_view_helpers import MaterializedViewMixin
 from pycds.weather_anomaly import \
-    DiscardedObs, \
     DailyMaxTemperature, DailyMinTemperature, \
     MonthlyAverageOfDailyMaxTemperature, MonthlyAverageOfDailyMinTemperature, \
     MonthlyTotalPrecipitation
 
-base_views = [DiscardedObs]
 daily_views = [DailyMaxTemperature, DailyMinTemperature]
 monthly_views = [MonthlyAverageOfDailyMaxTemperature, MonthlyAverageOfDailyMinTemperature, MonthlyTotalPrecipitation]
 
@@ -18,13 +16,9 @@ def manage_views(session, operation, which_views):
 
     # Order matters
     views = {
-        'base': base_views,
-        'daily': base_views + daily_views,
-        'monthly': base_views + monthly_views,
-        'all': base_views + daily_views + monthly_views,
-        'base-only': base_views,
-        'daily-only': daily_views,
+        'daily': daily_views,
         'monthly-only': monthly_views,
+        'all': daily_views + monthly_views,
     }[which_views]
 
     for view in views:

--- a/pycds/manage_views.py
+++ b/pycds/manage_views.py
@@ -1,0 +1,27 @@
+import logging
+
+from pycds.materialized_view_helpers import MaterializedViewMixin
+from pycds.weather_anomaly import \
+    DiscardedObs, \
+    DailyMaxTemperature, DailyMinTemperature, \
+    MonthlyAverageOfDailyMaxTemperature, MonthlyAverageOfDailyMinTemperature, \
+    MonthlyTotalPrecipitation
+
+base_views = [DiscardedObs]
+daily_views = [DailyMaxTemperature, DailyMinTemperature]
+monthly_views = [MonthlyAverageOfDailyMaxTemperature, MonthlyAverageOfDailyMinTemperature, MonthlyTotalPrecipitation]
+
+
+def manage_views(session, operation, which_views):
+
+    # Order matters
+    views = {
+        'daily': base_views + daily_views,
+        'monthly': base_views + monthly_views,
+        'all': base_views + daily_views + monthly_views
+    }[which_views]
+
+    for view in views:
+        if operation == 'create' or issubclass(view, MaterializedViewMixin):
+            logging.info("{} '{}'".format(operation.capitalize(), view.viewname()))
+            getattr(view, operation)(session)

--- a/pycds/manage_views.py
+++ b/pycds/manage_views.py
@@ -11,17 +11,23 @@ base_views = [DiscardedObs]
 daily_views = [DailyMaxTemperature, DailyMinTemperature]
 monthly_views = [MonthlyAverageOfDailyMaxTemperature, MonthlyAverageOfDailyMinTemperature, MonthlyTotalPrecipitation]
 
+logger = logging.getLogger(__name__)
+
 
 def manage_views(session, operation, which_views):
 
     # Order matters
     views = {
+        'base': base_views,
         'daily': base_views + daily_views,
         'monthly': base_views + monthly_views,
-        'all': base_views + daily_views + monthly_views
+        'all': base_views + daily_views + monthly_views,
+        'base-only': base_views,
+        'daily-only': daily_views,
+        'monthly-only': monthly_views,
     }[which_views]
 
     for view in views:
         if operation == 'create' or issubclass(view, MaterializedViewMixin):
-            logging.info("{} '{}'".format(operation.capitalize(), view.viewname()))
+            logger.info("{} '{}'".format(operation.capitalize(), view.viewname()))
             getattr(view, operation)(session)

--- a/pycds/manage_views.py
+++ b/pycds/manage_views.py
@@ -12,14 +12,20 @@ monthly_views = [MonthlyAverageOfDailyMaxTemperature, MonthlyAverageOfDailyMinTe
 logger = logging.getLogger(__name__)
 
 
-def manage_views(session, operation, which_views):
+def manage_views(session, operation, which_set):
+    """Apply specified view management operation to specified set of views.
 
-    # Order matters
+    :param session: (sqlalchemy.orm.session.Session) database session
+    :param operation: (str) operation to apply, one of 'create', 'refresh' (actually the name of any valid method
+        of a materialized view can be supplied here, but the invoking script limits it to above list).
+    :param which_set: (str) which set of views to apply the operation to, one of 'daily', 'monthly-only', 'all'
+    """
+
     views = {
         'daily': daily_views,
         'monthly-only': monthly_views,
-        'all': daily_views + monthly_views,
-    }[which_views]
+        'all': daily_views + monthly_views, # Order of view updating matters
+    }[which_set]
 
     for view in views:
         if operation == 'create' or issubclass(view, MaterializedViewMixin):

--- a/pycds/weather_anomaly.py
+++ b/pycds/weather_anomaly.py
@@ -37,6 +37,7 @@ Materialized View: Monthly total precipitation (MonthlyTotalPrecipitation)
 """
 
 import sqlalchemy
+from sqlalchemy import MetaData
 from sqlalchemy import select, union
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.schema import DDL
@@ -46,7 +47,7 @@ from pycds import ObsRawNativeFlags, NativeFlag, ObsRawPCICFlags, PCICFlag
 from pycds.materialized_view_helpers import MaterializedViewMixin
 from pycds.view_helpers import ViewMixin
 
-Base = declarative_base()
+Base = declarative_base(metadata=MetaData(schema='crmp'))  # TODO: refactor metadata
 metadata = Base.metadata
 
 

--- a/pycds/weather_anomaly.py
+++ b/pycds/weather_anomaly.py
@@ -51,6 +51,7 @@ Base = declarative_base(metadata=MetaData(schema='crmp'))
 metadata = Base.metadata
 
 
+# TODO: Remove
 class DiscardedObs(Base, ViewMixin):
     """This class represents a view which returns the id's of all observations that have been discarded,
     either by a native flag or a PCIC flag."""
@@ -125,30 +126,43 @@ def daily_temperature_extremum_selectable(extremum):
     """
 
     return text('''
-        SELECT
-            hx.history_id AS history_id,
-            obs.vars_id AS vars_id,
-            effective_day(obs.obs_time, '{0}', hx.freq::varchar) AS obs_day,
-            {0}(obs.datum) AS statistic,
-            sum(
-                CASE hx.freq
-                WHEN 'daily' THEN 1.0::float
-                WHEN '1-hourly' THEN (1/24.0)::float
-                WHEN '12-hourly' THEN 0.5::float
-                END
-            ) AS data_coverage
-        FROM
-            obs_raw AS obs
-            INNER JOIN meta_vars AS vars USING (vars_id)
-            INNER JOIN meta_history AS hx USING (history_id)
-        WHERE
-            obs.obs_raw_id NOT IN (SELECT id FROM discarded_obs_v)
-            AND vars.standard_name = 'air_temperature'
-            AND vars.cell_method IN ('time: {0}imum', 'time: point', 'time: mean')
-            AND hx.freq IN ('1-hourly', '12-hourly', 'daily')
-        GROUP BY
-            hx.history_id, vars_id, obs_day
-    '''.format(extremum))\
+WITH keepers AS (
+    SELECT
+        obs.*
+    FROM
+        obs_raw AS obs
+        LEFT JOIN obs_raw_native_flags  AS ornf ON (obs.obs_raw_id = ornf.obs_raw_id)
+        LEFT JOIN meta_native_flag      AS mnf  ON (ornf.native_flag_id = mnf.native_flag_id)
+        LEFT JOIN obs_raw_pcic_flags    AS orpf ON (obs.obs_raw_id = orpf.obs_raw_id)
+        LEFT JOIN meta_pcic_flag        AS mpf  ON (orpf.pcic_flag_id = mpf.pcic_flag_id)
+    GROUP BY
+        obs.obs_raw_id
+    HAVING
+        BOOL_OR(COALESCE(mnf.discard, FALSE)) = FALSE
+        AND BOOL_OR(COALESCE(mpf.discard, FALSE)) = FALSE
+)
+SELECT
+    hx.history_id AS history_id,
+    obs.vars_id AS vars_id,
+    effective_day(obs.obs_time, '{0}', hx.freq::varchar) AS obs_day,
+    {0}(obs.datum) AS statistic,
+    sum(
+        CASE hx.freq
+        WHEN 'daily' THEN 1.0::float
+        WHEN '1-hourly' THEN (1/24.0)::float
+        WHEN '12-hourly' THEN 0.5::float
+        END
+    ) AS data_coverage
+FROM
+    keepers AS obs
+    INNER JOIN meta_vars AS vars USING (vars_id)
+    INNER JOIN meta_history AS hx USING (history_id)
+WHERE
+    vars.standard_name = 'air_temperature'
+    AND vars.cell_method IN ('time: {0}imum', 'time: point', 'time: mean')
+    AND hx.freq IN ('1-hourly', '12-hourly', 'daily')
+GROUP BY
+    hx.history_id, vars_id, obs_day    '''.format(extremum))\
         .columns(
                 column('history_id'),
                 column('vars_id'),

--- a/pycds/weather_anomaly.py
+++ b/pycds/weather_anomaly.py
@@ -96,7 +96,7 @@ sqlalchemy.event.listen(
 
 
 # Common subquery used in daily temperature extrema and monthly total precip queries
-keepers = '''
+undiscarded_observations = '''
     SELECT
         obs.*
     FROM
@@ -146,7 +146,7 @@ def daily_temperature_extremum_selectable(extremum):
             AND hx.freq IN ('1-hourly', '12-hourly', 'daily')
         GROUP BY
             hx.history_id, vars_id, obs_day
-    '''.format(extremum, keepers))\
+    '''.format(extremum, undiscarded_observations))\
         .columns(
                 column('history_id'),
                 column('vars_id'),
@@ -250,7 +250,7 @@ class MonthlyTotalPrecipitation(Base, MaterializedViewMixin):
             GROUP BY
                 hx.history_id, vars_id, obs_month
         ) AS temp
-    '''.format(keepers))\
+    '''.format(undiscarded_observations))\
         .columns(
             column('history_id'),
             column('vars_id'),

--- a/pycds/weather_anomaly.py
+++ b/pycds/weather_anomaly.py
@@ -47,7 +47,7 @@ from pycds import ObsRawNativeFlags, NativeFlag, ObsRawPCICFlags, PCICFlag
 from pycds.materialized_view_helpers import MaterializedViewMixin
 from pycds.view_helpers import ViewMixin
 
-Base = declarative_base(metadata=MetaData(schema='crmp'))  # TODO: refactor metadata
+Base = declarative_base(metadata=MetaData(schema='crmp'))
 metadata = Base.metadata
 
 
@@ -90,7 +90,7 @@ class DiscardedObs(Base, ViewMixin):
 sqlalchemy.event.listen(
     metadata, 'before_create',
     DDL('''
-        CREATE OR REPLACE FUNCTION effective_day(
+        CREATE OR REPLACE FUNCTION crmp.effective_day(
           obs_time timestamp without time zone, extremum varchar, freq varchar = ''
         )
         RETURNS timestamp without time zone AS $$

--- a/pycds/weather_anomaly.py
+++ b/pycds/weather_anomaly.py
@@ -128,7 +128,7 @@ def daily_temperature_extremum_selectable(extremum):
         SELECT
             hx.history_id AS history_id,
             obs.vars_id AS vars_id,
-            effective_day(obs.obs_time, '{0}', hx.freq) AS obs_day,
+            effective_day(obs.obs_time, '{0}', hx.freq::varchar) AS obs_day,
             {0}(obs.datum) AS statistic,
             sum(
                 CASE hx.freq

--- a/scripts/manage-views.py
+++ b/scripts/manage-views.py
@@ -24,8 +24,8 @@ Examples:
     parser.add_argument('-d', '--dsn', help='Database DSN in which to manage views')
     parser.add_argument('operation', help="Operation to perform (create | refresh)",
                         choices=['create', 'refresh'])
-    parser.add_argument('views', help="Views to affect (daily | monthly | all)",
-                        choices=['daily', 'monthly', 'all'])
+    parser.add_argument('views', help="Views to affect",
+                        choices=['base', 'daily', 'monthly', 'all', 'base-only', 'daily-only', 'monthly-only'])
     args = parser.parse_args()
 
     logger = logging.getLogger(__name__)

--- a/scripts/manage-views.py
+++ b/scripts/manage-views.py
@@ -8,16 +8,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 import pycds
-from pycds.materialized_view_helpers import MaterializedViewMixin
-from pycds.weather_anomaly import \
-    DiscardedObs, \
-    DailyMaxTemperature, DailyMinTemperature, \
-    MonthlyAverageOfDailyMaxTemperature, MonthlyAverageOfDailyMinTemperature, \
-    MonthlyTotalPrecipitation
-
-base_views = [DiscardedObs]
-daily_views = [DailyMaxTemperature, DailyMinTemperature]
-monthly_views = [MonthlyAverageOfDailyMaxTemperature, MonthlyAverageOfDailyMinTemperature, MonthlyTotalPrecipitation]
+from pycds.manage_views import manage_views
 
 if __name__ == '__main__':
     parser = ArgumentParser(description="""Script to manage views in the PCDS/CRMP database.
@@ -45,16 +36,6 @@ Examples:
     session.execute('SET search_path TO crmp')
     pycds.weather_anomaly.Base.metadata.create_all(bind=engine)
 
-    # Order matters
-    views = {
-        'daily': base_views + daily_views,
-        'monthly': base_views + monthly_views,
-        'all': base_views + daily_views + monthly_views
-    }[args.views]
-
-    for view in views:
-        if args.operation == 'create' or issubclass(view, MaterializedViewMixin):
-            logging.info("{} '{}'".format(args.operation.capitalize(), view.viewname()))
-            getattr(view, args.operation)(session)
+    manage_views(session, args.operation, args.views)
 
     session.commit()

--- a/scripts/manage-views.py
+++ b/scripts/manage-views.py
@@ -22,6 +22,11 @@ Examples:
     postgresql+pg8000://scott:tiger@localhost/mydatabase
 """)
     parser.add_argument('-d', '--dsn', help='Database DSN in which to manage views')
+    log_level_choices = 'NOTSET DEBUG INFO WARNING ERROR CRITICAL'.split()
+    parser.add_argument('-s', '--scriptloglevel', help='Script logging level',
+                        choices=log_level_choices, default='INFO')
+    parser.add_argument('-e', '--dbengloglevel', help='Database engine logging level',
+                        choices=log_level_choices, default='WARNING')
     parser.add_argument('operation', help="Operation to perform",
                         choices=['create', 'refresh'])
     parser.add_argument('views', help="Views to affect",
@@ -34,12 +39,11 @@ Examples:
 
     sa_logger = logging.getLogger('sqlalchemy.engine')
     sa_logger.addHandler(handler)
-    sa_logger.setLevel(logging.DEBUG)
-    sa_logger.debug('test test test')
+    sa_logger.setLevel(getattr(logging, args.dbengloglevel))
 
     mv_logger = logging.getLogger(pycds.manage_views.__name__)
     mv_logger.addHandler(handler)
-    mv_logger.setLevel(logging.DEBUG)
+    mv_logger.setLevel(getattr(logging, args.scriptloglevel))
 
     engine = create_engine(args.dsn)
     session = sessionmaker(bind=engine)()

--- a/scripts/manage-views.py
+++ b/scripts/manage-views.py
@@ -28,18 +28,23 @@ Examples:
                         choices=['daily', 'monthly-only', 'all'])
     args = parser.parse_args()
 
-    logging.getLogger('sqlalchemy.engine').setLevel(logging.DEBUG)
-    logger = logging.getLogger(pycds.manage_views.__name__)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s: %(message)s')
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    logger.setLevel(logging.DEBUG)
+
+    sa_logger = logging.getLogger('sqlalchemy.engine')
+    sa_logger.addHandler(handler)
+    sa_logger.setLevel(logging.DEBUG)
+    sa_logger.debug('test test test')
+
+    mv_logger = logging.getLogger(pycds.manage_views.__name__)
+    mv_logger.addHandler(handler)
+    mv_logger.setLevel(logging.DEBUG)
 
     engine = create_engine(args.dsn)
     session = sessionmaker(bind=engine)()
 
-    logger.debug('creating all ORM objects')
+    mv_logger.debug('creating all ORM objects')
     pycds.Base.metadata.create_all(bind=engine)
     pycds.weather_anomaly.Base.metadata.create_all(bind=engine)
 
@@ -47,9 +52,9 @@ Examples:
         sp = session.execute('SHOW search_path')
         return ','.join([r.search_path for r in sp])
 
-    logger.debug('search_path before: {}'.format(search_path()))
+    mv_logger.debug('search_path before: {}'.format(search_path()))
     session.execute('SET search_path TO crmp, public')
-    logger.debug('search_path after: {}'.format(search_path()))
+    mv_logger.debug('search_path after: {}'.format(search_path()))
 
     manage_views(session, args.operation, args.views)
 

--- a/scripts/manage-views.py
+++ b/scripts/manage-views.py
@@ -28,17 +28,18 @@ Examples:
                         choices=['daily', 'monthly-only', 'all'])
     args = parser.parse_args()
 
+    logging.getLogger('sqlalchemy.engine').setLevel(logging.DEBUG)
     logger = logging.getLogger(pycds.manage_views.__name__)
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s')
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s: %(message)s')
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
-    logger.setHandler(handler)
+    logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
 
     engine = create_engine(args.dsn)
     session = sessionmaker(bind=engine)()
 
-    logger.DEBUG('creating all ORM objects')
+    logger.debug('creating all ORM objects')
     pycds.Base.metadata.create_all(bind=engine)
     pycds.weather_anomaly.Base.metadata.create_all(bind=engine)
 
@@ -46,9 +47,9 @@ Examples:
         sp = session.execute('SHOW search_path')
         return ','.join([r.search_path for r in sp])
 
-    logger.DEBUG('search_path before: {}'.format(search_path()))
+    logger.debug('search_path before: {}'.format(search_path()))
     session.execute('SET search_path TO crmp, public')
-    logger.DEBUG('search_path after: {}'.format(search_path()))
+    logger.debug('search_path after: {}'.format(search_path()))
 
     manage_views(session, args.operation, args.views)
 

--- a/scripts/manage-views.py
+++ b/scripts/manage-views.py
@@ -7,6 +7,7 @@ from argparse import ArgumentParser
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+import pycds
 from pycds.materialized_view_helpers import MaterializedViewMixin
 from pycds.weather_anomaly import \
     DiscardedObs, \
@@ -42,6 +43,7 @@ Examples:
     session = sessionmaker(bind=engine)()
 
     session.execute('SET search_path TO crmp')
+    pycds.weather_anomaly.Base.metadata.create_all(bind=engine)
 
     # Order matters
     views = {

--- a/scripts/manage-views.py
+++ b/scripts/manage-views.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import sessionmaker
 
 import pycds
 from pycds.manage_views import manage_views
+import pycds.weather_anomaly
 
 if __name__ == '__main__':
     parser = ArgumentParser(description="""Script to manage views in the PCDS/CRMP database.
@@ -23,7 +24,7 @@ Examples:
     parser.add_argument('-d', '--dsn', help='Database DSN in which to manage views')
     parser.add_argument('operation', help="Operation to perform (create | refresh)",
                         choices=['create', 'refresh'])
-    parser.add_argument('views', help="Views to refresh (daily | monthly | all)",
+    parser.add_argument('views', help="Views to affect (daily | monthly | all)",
                         choices=['daily', 'monthly', 'all'])
     args = parser.parse_args()
 
@@ -33,7 +34,10 @@ Examples:
     engine = create_engine(args.dsn)
     session = sessionmaker(bind=engine)()
 
-    session.execute('SET search_path TO crmp')
+    pycds.Base.metadata.create_all(bind=engine)
+    pycds.weather_anomaly.Base.metadata.create_all(bind=engine)
+
+    session.execute('SET search_path TO crmp, public')
 
     manage_views(session, args.operation, args.views)
 

--- a/scripts/manage-views.py
+++ b/scripts/manage-views.py
@@ -41,6 +41,8 @@ Examples:
     engine = create_engine(args.dsn)
     session = sessionmaker(bind=engine)()
 
+    session.execute('SET search_path TO crmp')
+
     # Order matters
     views = {
         'daily': base_views + daily_views,
@@ -51,4 +53,6 @@ Examples:
     for view in views:
         if args.operation == 'create' or issubclass(view, MaterializedViewMixin):
             logging.info("{} '{}'".format(args.operation.capitalize(), view.viewname()))
-            getattr(view, args.operation)()
+            getattr(view, args.operation)(session)
+
+    session.commit()

--- a/scripts/manage-views.py
+++ b/scripts/manage-views.py
@@ -63,3 +63,5 @@ Examples:
     manage_views(session, args.operation, args.views)
 
     session.commit()
+
+    mv_logger.info('Done')

--- a/scripts/manage-views.py
+++ b/scripts/manage-views.py
@@ -34,7 +34,6 @@ Examples:
     session = sessionmaker(bind=engine)()
 
     session.execute('SET search_path TO crmp')
-    pycds.weather_anomaly.Base.metadata.create_all(bind=engine)
 
     manage_views(session, args.operation, args.views)
 

--- a/scripts/manage-views.py
+++ b/scripts/manage-views.py
@@ -22,10 +22,10 @@ Examples:
     postgresql+pg8000://scott:tiger@localhost/mydatabase
 """)
     parser.add_argument('-d', '--dsn', help='Database DSN in which to manage views')
-    parser.add_argument('operation', help="Operation to perform (create | refresh)",
+    parser.add_argument('operation', help="Operation to perform",
                         choices=['create', 'refresh'])
     parser.add_argument('views', help="Views to affect",
-                        choices=['base', 'daily', 'monthly', 'all', 'base-only', 'daily-only', 'monthly-only'])
+                        choices=['daily', 'monthly-only', 'all'])
     args = parser.parse_args()
 
     logger = logging.getLogger(pycds.manage_views.__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import sys
 import testing.postgresql
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.schema import CreateSchema
 import pytest
 from pytest import fixture
 
@@ -24,6 +25,7 @@ def engine():
     with testing.postgresql.Postgresql() as pg:
         engine = create_engine(pg.url())
         engine.execute("create extension postgis")
+        engine.execute(CreateSchema('crmp'))
         pycds.Base.metadata.create_all(bind=engine)
         pycds.weather_anomaly.Base.metadata.create_all(bind=engine)
         yield engine
@@ -43,6 +45,7 @@ def mod_blank_postgis_session():
     with testing.postgresql.Postgresql() as pg:
         engine = create_engine(pg.url())
         engine.execute("create extension postgis")
+        engine.execute(CreateSchema('crmp'))
         sesh = sessionmaker(bind=engine)()
         yield sesh
 
@@ -59,6 +62,7 @@ def blank_postgis_session():
     with testing.postgresql.Postgresql() as pg:
         engine = create_engine(pg.url())
         engine.execute("create extension postgis")
+        engine.execute(CreateSchema('crmp'))
         sesh = sessionmaker(bind=engine)()
 
         yield sesh

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,10 @@ def engine():
 def session(engine):
     """Single-test database session. All session actions are rolled back on teardown"""
     session = sessionmaker(bind=engine)()
+    # Default search path is `"$user", public`. Need to reset that to search crmp (for our db/orm content) and
+    # public (for postgis functions)
+    session.execute('SET search_path TO crmp, public')
+    # print('\nsearch_path', [r for r in session.execute('SHOW search_path')])
     yield session
     session.rollback()
     session.close()

--- a/tests/test_daily_temperature_extrema.py
+++ b/tests/test_daily_temperature_extrema.py
@@ -19,7 +19,6 @@ from sqlalchemy.sql import text
 
 from pycds.util import generic_sesh
 from pycds import Network, Station, History, Variable, Obs, NativeFlag, PCICFlag
-from pycds.weather_anomaly import DiscardedObs
 from pycds.weather_anomaly import DailyMaxTemperature, DailyMinTemperature
 
 
@@ -48,7 +47,7 @@ def describe_function_effective__day():
         assert result[0]['eday'] == expected_day[extremum][freq][obs_time]
 
 
-views = [DiscardedObs, DailyMaxTemperature, DailyMinTemperature]
+views = [DailyMaxTemperature, DailyMinTemperature]
 refreshable_views = [DailyMaxTemperature, DailyMinTemperature]
 
 

--- a/tests/test_daily_temperature_extrema.py
+++ b/tests/test_daily_temperature_extrema.py
@@ -182,7 +182,13 @@ def describe_with_1_network():
                         assert [r.data_coverage for r in results] == approx([3.0/24.0, 4.0/24.0])
 
                 def describe_with_many_observations_in_one_day_bis():
-                    '''Set up observations for native flag tests'''
+                    '''Set up observations for flag tests.
+                    24 observations total, one for each hour in the single day Jan 1, 2000.
+                    Therefore daily temperature extrema views will have one row - for that date.
+                    Flags will be associated to these observations that cause a certain number of observations
+                    to be excluded from the daily temperature extrema calculations.
+                    This exclusion will affect the data_coverage figure for the (one) row returned - discards will
+                    cause data_coverage to be less than 1.0 by the fraction of observations excluded.'''
 
                     num_obs_for_native = 12
                     num_obs_for_pcic = 12
@@ -199,11 +205,10 @@ def describe_with_1_network():
                         for sesh in generic_sesh(variable_sesh, observations):
                             yield sesh
 
-                    # It would be better to DRY up describe_with_native_flags and describe_with_pcic_flags by
-                    # parametrizing, but pytest doesn't yet support parameterization over fixtures:
-                    # see https://github.com/pytest-dev/pytest/issues/349
-                    def describe_with_native_flags():
-                        '''2 native flags, 1 discard, 1 not discard'''
+                    def describe_with_flags():
+                        '''2 native flags, 1 discard, 1 not discard.
+                        Ditto pcic flags.
+                        '''
 
                         @fixture
                         def flag_sesh(obs_sesh, native_flag_discard, native_flag_non_discard,
@@ -212,10 +217,22 @@ def describe_with_1_network():
                                                                 pcic_flag_discard, pcic_flag_non_discard]):
                                 yield sesh
 
-                        def describe_with_native_flag_associations():
-                            '''m < n associations of discard native flag to observations;
-                            k < n associations of not discard native flag to observations, some on same observations
-                                as discard flags'''
+                        def describe_with_flag_associations():
+                            '''Associate flags to various subsets of the observations. Specifically:
+
+                            For native flags:
+                            - associate discard flags to num_discarded (=5) observations (id = 0..4)
+                            - associate non-discard flags to num_non_discarded (=5) observations,
+                              some overlapping discards (id = 3..7)
+
+                            For pcic flags:
+                            - associate discard flags to num_discarded (=5) observations (id = 12..16)
+                            - associate non-discard flags to num_non_discarded (=5) observations,
+                              some overlapping discards (id = 15..19)
+
+                            Note that native and pcic flag associations do not overlap. That would be better to test,
+                            but also harder ... lazy/pragmatic
+                            '''
 
                             # num_discarded must be different than num_obs/2 to guarantee test is unambiguous
                             num_discarded = 5
@@ -231,7 +248,7 @@ def describe_with_1_network():
                                 native flags and to pcic flags do not overlap.
 
                                 This kind of indirect parameterization is a substitute for the absent ability of pytest
-                                to parametrize over fixtures, which would make this whole things somewhat simpler to
+                                to parametrize over fixtures, which would make this whole thing somewhat simpler to
                                 code and understand. In any case, it enables us to perform the same tests for several
                                 different combinations of flagging of observations without repetitive code.
                                 """

--- a/tests/test_daily_temperature_extrema.py
+++ b/tests/test_daily_temperature_extrema.py
@@ -53,6 +53,8 @@ refreshable_views = [DailyMaxTemperature, DailyMinTemperature]
 @fixture(scope='module')
 def with_views_sesh(mod_empty_database_session):
     sesh = mod_empty_database_session
+    sesh.execute('SET search_path TO crmp')
+    print('\nwith_views_sesh: search_path', [r for r in sesh.execute('SHOW search_path')])
     for view in views:
         view.create(sesh)
     yield sesh

--- a/tests/test_manage_views.py
+++ b/tests/test_manage_views.py
@@ -1,0 +1,29 @@
+from pytest import mark
+
+from sqlalchemy import text, inspect
+
+import pycds
+from pycds.manage_views import manage_views
+
+
+base_view = ['discarded_obs_v']
+daily_views = ['daily_max_temperature_mv', 'daily_min_temperature_mv']
+monthly_views = ['monthly_average_of_daily_max_temperature_mv', 'monthly_average_of_daily_min_temperature_mv',
+                 'monthly_total_precipitation_mv']
+
+
+@mark.parametrize(', operation, view, view_names', [
+    ('create', 'all', daily_views + monthly_views),
+])
+def test_it(engine, session, operation, view, view_names):
+    # pycds.weather_anomaly.Base.metadata.create_all(bind=engine)  # this proves unnecessary
+    table_names = inspect(engine).get_table_names()
+    # print('before', table_names)
+    for vn in view_names:
+        assert vn not in table_names
+    manage_views(session, operation, view)
+    session.commit()
+    table_names = inspect(engine).get_table_names()
+    # print('after', table_names)
+    for vn in view_names:
+        assert vn in table_names

--- a/tests/test_manage_views.py
+++ b/tests/test_manage_views.py
@@ -13,10 +13,9 @@ from sqlalchemy import text, inspect
 import pycds
 import pycds.weather_anomaly
 from pycds import Obs
-from pycds.manage_views import base_views, daily_views, monthly_views, manage_views
+from pycds.manage_views import daily_views, monthly_views, manage_views
 
 
-base_view_names = [v.viewname() for v in base_views]
 daily_view_names = [v.viewname() for v in daily_views]
 monthly_view_names = [v.viewname() for v in monthly_views]
 
@@ -70,7 +69,7 @@ def per_test_session(per_test_engine):
 
 @mark.parametrize('what, exp_matview_names', [
     ('daily', daily_view_names),
-    # `create monthly` will fail if the daily views do not already exist, succeed if they do;
+    # `create monthly-only` will fail if the daily views do not already exist, succeed if they do;
     # we don't bother setting up the test machinery to test that
     ('all', daily_view_names + monthly_view_names),
 ])
@@ -83,7 +82,6 @@ def test_create(per_test_engine, per_test_session, what, exp_matview_names):
             for name in expected_names:
                 assert (present and (name in actual_names)) or (not present and (name not in actual_names))
 
-        check(base_view_names, inspect(per_test_engine).get_view_names(schema='crmp'))
         check(exp_matview_names, inspect(per_test_engine).get_table_names(schema='crmp'))
 
     check_views_and_tables(False)
@@ -97,7 +95,7 @@ def session_with_views(session):
     """Test fixture for manage_views('refresh'): Session with views defined."""
     logging.getLogger('sqlalchemy.engine').setLevel(logging.DEBUG)
     print('\nsession_with_views: SETUP')
-    views = base_views + daily_views + monthly_views
+    views = daily_views + monthly_views
     for view in views:
         view.create(session)
     session.flush()
@@ -110,7 +108,7 @@ def session_with_views(session):
 
 @mark.parametrize('what, exp_views', [
     ('daily', daily_views),
-    # `refresh monthly` will fail if the daily views haven't been refreshed, succeed if they do;
+    # `refresh monthly-only` will fail if the daily views haven't been refreshed, succeed if they do;
     # we don't bother setting up the test machinery to test that
     ('all', daily_views + monthly_views),
 ])

--- a/tests/test_manage_views.py
+++ b/tests/test_manage_views.py
@@ -1,4 +1,5 @@
-from pytest import mark
+from pytest import fixture, mark
+import testing.postgresql
 
 from sqlalchemy import text, inspect
 
@@ -6,23 +7,42 @@ import pycds
 from pycds.manage_views import manage_views
 
 
-base_view = ['discarded_obs_v']
-daily_views = ['daily_max_temperature_mv', 'daily_min_temperature_mv']
-monthly_views = ['monthly_average_of_daily_max_temperature_mv', 'monthly_average_of_daily_min_temperature_mv',
+base_view_names = ['discarded_obs_v']
+daily_view_names = ['daily_max_temperature_mv', 'daily_min_temperature_mv']
+monthly_view_names = ['monthly_average_of_daily_max_temperature_mv', 'monthly_average_of_daily_min_temperature_mv',
                  'monthly_total_precipitation_mv']
 
 
-@mark.parametrize(', operation, view, view_names', [
-    ('create', 'all', daily_views + monthly_views),
-])
-def test_it(engine, session, operation, view, view_names):
-    table_names = inspect(engine).get_table_names()
-    # print('before', table_names)
-    for vn in view_names:
-        assert vn not in table_names
-    manage_views(session, operation, view)
+@fixture()
+def cleanup_db_session(session):
+    """To cause manage_views to take effect, session.commit() must be called.
+    Unfortunately, that durably modifies the database; after a commit, the normal `session` rollback doesn't have any
+    effect. So either we need to set up a database engine with 'function' scope, not 'session', or we need to clean
+    up the database each time. This fixture implements the latter."""
+    yield session
+    for name in reversed(daily_view_names + monthly_view_names):
+        session.execute('DROP TABLE IF EXISTS crmp.{}'.format(name))
+    for name in reversed(base_view_names):
+        session.execute('DROP VIEW IF EXISTS crmp.{}'.format(name))
     session.commit()
-    table_names = inspect(engine).get_table_names()
-    # print('after', table_names)
-    for vn in view_names:
-        assert vn in table_names
+
+@mark.parametrize(', operation, view, exp_matview_names', [
+    ('create', 'daily', daily_view_names),
+    # `create monthly` will fail if the daily views do not already exist, succeed if they do;
+    # we don't bother setting up the test machinery to test that
+    ('create', 'all', daily_view_names + monthly_view_names),
+])
+def test_it(engine, cleanup_db_session, operation, view, exp_matview_names):
+
+    def check_views_and_tables(present):
+        def check(expected_names, actual_names):
+            for name in expected_names:
+                assert (present and (name in actual_names)) or (not present and (name not in actual_names))
+
+        check(base_view_names, inspect(engine).get_view_names(schema='crmp'))
+        check(exp_matview_names, inspect(engine).get_table_names(schema='crmp'))
+
+    check_views_and_tables(False)
+    manage_views(cleanup_db_session, operation, view)
+    cleanup_db_session.commit()
+    check_views_and_tables(True)

--- a/tests/test_manage_views.py
+++ b/tests/test_manage_views.py
@@ -1,48 +1,126 @@
+import datetime
 from pytest import fixture, mark
 import testing.postgresql
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.schema import CreateSchema
 from sqlalchemy import text, inspect
 
 import pycds
-from pycds.manage_views import manage_views
+from pycds import Obs
+from pycds.manage_views import base_views, daily_views, monthly_views, manage_views
 
 
-base_view_names = ['discarded_obs_v']
-daily_view_names = ['daily_max_temperature_mv', 'daily_min_temperature_mv']
-monthly_view_names = ['monthly_average_of_daily_max_temperature_mv', 'monthly_average_of_daily_min_temperature_mv',
-                 'monthly_total_precipitation_mv']
+base_view_names = [v.viewname() for v in base_views]
+daily_view_names = [v.viewname() for v in daily_views]
+monthly_view_names = [v.viewname() for v in monthly_views]
 
 
-@fixture()
-def cleanup_db_session(session):
-    """To cause manage_views to take effect, session.commit() must be called.
-    Unfortunately, that durably modifies the database; after a commit, the normal `session` rollback doesn't have any
-    effect. So either we need to set up a database engine with 'function' scope, not 'session', or we need to clean
-    up the database each time. This fixture implements the latter."""
+@fixture(scope='function')
+def per_test_engine():
+    """Single-test database engine, so that we are starting with a clean database for each individual test.
+    Somewhat slow (computationally expensive) but simple. We need this mechanism because:
+
+    - to confirm that tables have been created, we use inspection
+      (http://docs.sqlalchemy.org/en/latest/core/reflection.html#fine-grained-reflection-with-inspector)
+    - ``inspect`` is bound to an engine, not a session
+    - any session which creates views has to commit its actions to make them visible to the engine
+    - commiting prevents the usual session rollback mechanism from working
+    - therefore we either must manually remove the tables on teardown of each session, or just use a fresh database
+    - we opt for the latter; the former proves unwieldy
+
+    Fortunately this mechanism is only necessary for testing the create operation."""
+    with testing.postgresql.Postgresql() as pg:
+        engine = create_engine(pg.url())
+        engine.execute("create extension postgis")
+        engine.execute(CreateSchema('crmp'))
+        pycds.Base.metadata.create_all(bind=engine)
+        pycds.weather_anomaly.Base.metadata.create_all(bind=engine)
+        yield engine
+
+
+@fixture
+def per_test_session(per_test_engine):
+    session = sessionmaker(bind=per_test_engine)()
+    # Default search path is `"$user", public`. Need to reset that to search crmp (for our db/orm content) and
+    # public (for postgis functions)
+    session.execute('SET search_path TO crmp, public')
+    # print('\nsearch_path', [r for r in session.execute('SHOW search_path')])
     yield session
-    for name in reversed(daily_view_names + monthly_view_names):
-        session.execute('DROP TABLE IF EXISTS crmp.{}'.format(name))
-    for name in reversed(base_view_names):
-        session.execute('DROP VIEW IF EXISTS crmp.{}'.format(name))
-    session.commit()
 
-@mark.parametrize(', operation, view, exp_matview_names', [
-    ('create', 'daily', daily_view_names),
+
+@mark.parametrize('what, exp_matview_names', [
+    ('daily', daily_view_names),
     # `create monthly` will fail if the daily views do not already exist, succeed if they do;
     # we don't bother setting up the test machinery to test that
-    ('create', 'all', daily_view_names + monthly_view_names),
+    ('all', daily_view_names + monthly_view_names),
 ])
-def test_it(engine, cleanup_db_session, operation, view, exp_matview_names):
+def test_create(per_test_engine, per_test_session, what, exp_matview_names):
 
     def check_views_and_tables(present):
         def check(expected_names, actual_names):
             for name in expected_names:
                 assert (present and (name in actual_names)) or (not present and (name not in actual_names))
 
-        check(base_view_names, inspect(engine).get_view_names(schema='crmp'))
-        check(exp_matview_names, inspect(engine).get_table_names(schema='crmp'))
+        check(base_view_names, inspect(per_test_engine).get_view_names(schema='crmp'))
+        check(exp_matview_names, inspect(per_test_engine).get_table_names(schema='crmp'))
 
     check_views_and_tables(False)
-    manage_views(cleanup_db_session, operation, view)
-    cleanup_db_session.commit()
+    manage_views(per_test_session, 'create', what)
+    per_test_session.commit()
     check_views_and_tables(True)
+
+
+@fixture
+def session_with_views(session):
+    """Test fixture for manage_views('refresh'): Session with views defined."""
+    print('\nsession_with_views: SETUP')
+    views = base_views + daily_views + monthly_views
+    for view in views:
+        view.create(session)
+    session.flush()
+    yield session
+    print('\nsession_with_views: TEARDOWN')
+    for view in reversed(views):
+        view.drop(session)
+    print('\nsession_with_views: DONE')
+
+
+@mark.parametrize('what, exp_views', [
+    ('daily', daily_views),
+    # `refresh monthly` will fail if the daily views haven't been refreshed, succeed if they do;
+    # we don't bother setting up the test machinery to test that
+    ('all', daily_views + monthly_views),
+])
+def test_refresh(session_with_views, what, exp_views,
+                 network1, station1, history_stn1_hourly, var_temp_point, var_precip_net1_1):
+
+    # initially, each view should be empty, because no data
+    for view in exp_views:
+        assert session_with_views.query(view).count() == 0
+
+    # Add observations (and all the equipment necessary therefor) so that the views will have something to chew
+    session = session_with_views
+    session.add(network1)
+    session.add(station1)
+    session.add(history_stn1_hourly)
+    session.add(var_temp_point)
+    session.add_all([
+        Obs(
+            variable=variable,
+            history=history_stn1_hourly,
+            time=datetime.datetime(2000, 1, 1, 1),
+            datum = 1.0
+        )
+        for variable in [var_temp_point, var_precip_net1_1]
+    ])
+    session.flush()
+
+    # chew
+    manage_views(session_with_views, 'refresh', what)
+    session_with_views.flush()
+
+    # now each view should contain something
+    for view in exp_views:
+        assert session_with_views.query(view).count() > 0

--- a/tests/test_manage_views.py
+++ b/tests/test_manage_views.py
@@ -16,7 +16,6 @@ monthly_views = ['monthly_average_of_daily_max_temperature_mv', 'monthly_average
     ('create', 'all', daily_views + monthly_views),
 ])
 def test_it(engine, session, operation, view, view_names):
-    # pycds.weather_anomaly.Base.metadata.create_all(bind=engine)  # this proves unnecessary
     table_names = inspect(engine).get_table_names()
     # print('before', table_names)
     for vn in view_names:

--- a/tests/test_testdb.py
+++ b/tests/test_testdb.py
@@ -9,7 +9,7 @@ def test_reflect_tables_into_session(blank_postgis_session):
     engine = blank_postgis_session.get_bind()
     create_test_database(engine)
 
-    res = blank_postgis_session.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public';")
+    res = blank_postgis_session.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = 'crmp';")
     res = [x[0] for x in res.fetchall()]
 
     assert set(res).issuperset(set(['meta_sensor', 'meta_contact', 'climo_obs_count_mv',

--- a/tests/test_wa_monthly_views_common.py
+++ b/tests/test_wa_monthly_views_common.py
@@ -32,7 +32,6 @@ from pytest import fixture, mark, approx
 from pycds.util import generic_sesh
 from pycds import Network, Station, History, Variable, Obs
 from pycds.weather_anomaly import \
-    DiscardedObs, \
     DailyMaxTemperature, DailyMinTemperature, \
     MonthlyAverageOfDailyMaxTemperature, MonthlyAverageOfDailyMinTemperature, \
     MonthlyTotalPrecipitation
@@ -41,7 +40,7 @@ from pycds.weather_anomaly import \
 views_to_refresh = [DailyMaxTemperature, DailyMinTemperature,
                      MonthlyAverageOfDailyMaxTemperature, MonthlyAverageOfDailyMinTemperature,
                      MonthlyTotalPrecipitation]
-views = [DiscardedObs] + views_to_refresh
+views = views_to_refresh
 
 
 @fixture(scope='function')

--- a/tests/test_wa_monthly_views_common.py
+++ b/tests/test_wa_monthly_views_common.py
@@ -43,14 +43,14 @@ views_to_refresh = [DailyMaxTemperature, DailyMinTemperature,
                      MonthlyTotalPrecipitation]
 views = [DiscardedObs] + views_to_refresh
 
-@fixture(scope='module')
-def with_views_sesh(mod_empty_database_session):
-    sesh = mod_empty_database_session
+
+@fixture(scope='function')
+def with_views_sesh(session):
     for view in views:
-        view.create(sesh)
-    yield sesh
+        view.create(session)
+    yield (session)
     for view in reversed(views):
-        view.drop(sesh)
+        view.drop(session)
 
 
 def refresh_views(sesh):


### PR DESCRIPTION
This branch started out as solely as a fix for the script `scripts/manage-views.py`. After a few minor issues were corrected, the main problem was that the script was attempting to create the views in and based on the wrong schema. 

The underlying problem was not with the script itself, but with the fact that the schema in actual use was not made explicit in ORM declarations and in test fixtures. Tests passed with tables, views and functions being created in the default schema (`$user` or perhaps `public`). When it came to real operations on the production database, however, using the default schema was incorrect.

This PR corrects the ambiguity around schema, with the side effect of correcting the script.

One outstanding question is why queries (`SELECT`s) originally functioned correctly without explicit schema declarations, but table and view creation failed. This is easily demonstrated but not easily explained; nowhere is there an explicit declaration that queries should search all available schemas, but it is apparently what happens. 

**Later answer**: Originally, the default `search_path` for my user was `'crmp, public'` (or something very like that); after permissions problems were sorted out, my `search_path` was the default `'$user, public'`, which caused various schema related failures. Nevertheless, the switch to explicit schema is valid and I believe worthwhile.

One caveat: It's not clear to me whether all code that depends on PyCDS will continue to work after merging these changes. If, as I believe is the case, all client code issues only queries (SELECTs), then it seems that `demo.py`, amongst other things, indicates no changes will be needed to client code. That magic 'all schemas' effect. **EDIT**: This musing unfounded now that the problem (see prev. para.) is understood.

Note: Creation of views and matview tables in the database proper occurs _without_ the declarative base metadata that specifies schema (because the compilation of these operations to SQL is not integrated with any metadata). And queries, using the ORM objects, occur _with_ that metadata. On this hypothesis, creation of the new `DerivedValue`/`obs_derived_values` table (which _is_ defined in the ORM), via `scripts/load-climate-baseline-values.py`, will proceed without needing to specify the schema explicitly in the script, as must be done for manage-views.