### PR TITLE
Resolves #22, Added --include-data flag

### DIFF
--- a/scripts/mktestdb.py
+++ b/scripts/mktestdb.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     parser.add_argument("-i",
                         "--include-data",
                         action='store_true',
-                        help="Include test data in build")
+                        help="Create a small test dataset in the new database")
     args = parser.parse_args()
 
     logger = logging.getLogger(__name__)

--- a/scripts/mktestdb.py
+++ b/scripts/mktestdb.py
@@ -3,22 +3,27 @@
 import sys
 import logging
 from argparse import ArgumentParser
-from pkg_resources import resource_filename
 
 from sqlalchemy import create_engine
 
 from pycds.util import create_test_database, create_test_data
-    
+
 if __name__ == '__main__':
     parser = ArgumentParser(description="Script to create a test CRMP database and write it to a test database. DSN strings are of form:\n\tdialect+driver://username:password@host:port/database\nExamples:\n\tpostgresql://scott:tiger@localhost/mydatabase\n\tpostgresql+psycopg2://scott:tiger@localhost/mydatabase\n\tpostgresql+pg8000://scott:tiger@localhost/mydatabase")
-    parser.add_argument("-d", "--dsn", help="Source database DSN from which to read ")
-    parser.add_argument("-t", "--testdsn", help="Destination DSN to write to")
+    parser.add_argument("-t",
+                        "--testdsn",
+                        help="Destination DSN to write to")
+    parser.add_argument("-i",
+                        "--include-data",
+                        action='store_true',
+                        help="Include test data in build")
     args = parser.parse_args()
-                        
+
     logger = logging.getLogger(__name__)
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-    read_engine = create_engine(args.dsn)
     write_engine = create_engine(args.testdsn)
 
     create_test_database(write_engine)
-    create_test_data(write_engine)
+
+    if(args.include_data):
+        create_test_data(write_engine)


### PR DESCRIPTION
Small update to mktestdb.py based on issue #22.  Added an option '**--include-data**' which creates database with test data.  By default the database will be empty unless the flag is added.  Furthermore, the '**read_engine**' variable and '**--dsn**' argument were both removed as  they are no longer being used.