### PR TITLE
Adds index definitions to the obs_raw table

### DIFF
--- a/pycds/__init__.py
+++ b/pycds/__init__.py
@@ -9,7 +9,7 @@ __all__ = [
 
 import sqlalchemy
 from sqlalchemy import MetaData
-from sqlalchemy import Table, Column, Integer, BigInteger, Float, String, Date
+from sqlalchemy import Table, Column, Integer, BigInteger, Float, String, Date, Index
 from sqlalchemy import DateTime, Boolean, ForeignKey, Numeric, Interval
 from sqlalchemy.ext.declarative import declarative_base, DeferredReflection
 from sqlalchemy.orm import relationship, backref
@@ -184,6 +184,13 @@ class Obs(Base):
         UniqueConstraint('obs_time', 'history_id', 'vars_id',
                          name='time_place_variable_unique'),
     )
+
+    # Indexes
+    mod_time_idx = Index('mod_time_idx', 'mod_time')
+    obs_raw_comp_idx = Index('obs_raw_comp_idx', 'obs_time', 'vars_id',
+                             'history_id')
+    obs_raw_history_id_idx = Index('obs_raw_history_id_idx', 'history_id')
+    obs_raw_id_idx = Index('obs_raw_id_idx', 'obs_raw_id')
 
 
 class Variable(Base):


### PR DESCRIPTION
``obs_raw`` is generally a big table. Usually on the order of hundreds of millions of rows. Searches on this table require a little assistance so they don't end up doing a sequential scan on the whole table (and take minutes to complete).

When we build the BC Provincial Climate Data Set using raw SQL, we put a set of indexes on every column of the table. Those definitions didn't get ported to ``pycds`` when we wrote it, so here they are now. Could someone (@rod-glover  or @corviday ) take a look at this and see if it makes sense?