### PR TITLE
Add migration version-check function

### DIFF
--- a/pycds/util.py
+++ b/pycds/util.py
@@ -1,5 +1,30 @@
 import pycds
 
+
+def check_migration_version(
+    executor,
+    schema_name=pycds.get_schema_name(),
+    # `version` must be kept up to date with latest migration
+    # a test checks it, however, in case you don't
+    version='8fd8f556c548',
+):
+    """Check that the migration version of the database schema is compatible
+    with the current version of this package.
+
+    This implementation is quick and easy, relying on manual updating of the
+    correct version number.
+    """
+    current = executor.execute(f"""
+        SELECT version_num 
+        FROM {schema_name}.alembic_version
+    """).scalar()
+    if  current != version:
+        raise ValueError(
+            f"Schema {schema_name} must be at Alembic version {version}; "
+            f"detected version {current}."
+        )
+
+
 # TODO: Does this have any current utility? It is not used in any current code.
 #  Also its result can be achieved with 1 line:
 #   ...statement.compile(compile_kwargs={"literal_binds": True}))

--- a/pycds/util.py
+++ b/pycds/util.py
@@ -37,14 +37,3 @@ def compile_query(statement, bind=None):
 
     compiler = LiteralCompiler(dialect, statement)
     return compiler.process(statement)
-
-
-def create_test_database(engine):
-    pycds.Base.metadata.create_all(bind=engine)
-
-
-
-
-
-
-

--- a/tests/alembic_migrations/test_check_migration_version.py
+++ b/tests/alembic_migrations/test_check_migration_version.py
@@ -1,0 +1,25 @@
+"""Test that `check_migration_version` passes on the latest migration
+and raises an exception on other versions.
+
+If this test fails, you must update `check_migration_version` with the latest
+migration version.
+"""
+import pytest
+from alembic import command
+from .alembicverify_util import prepare_schema_from_migrations
+from pycds.util import check_migration_version
+
+
+@pytest.mark.usefixtures('new_db_left')
+def test_check_migration_version(
+        uri_left, alembic_config_left, db_setup, env_config,
+):
+    engine, script = prepare_schema_from_migrations(
+        uri_left, alembic_config_left, db_setup=db_setup
+    )
+    check_migration_version(engine)
+
+    command.downgrade(alembic_config_left, '-1')
+
+    with pytest.raises(ValueError):
+        check_migration_version(engine)

--- a/tests/alembic_migrations/test_check_migration_version.py
+++ b/tests/alembic_migrations/test_check_migration_version.py
@@ -17,9 +17,14 @@ def test_check_migration_version(
     engine, script = prepare_schema_from_migrations(
         uri_left, alembic_config_left, db_setup=db_setup
     )
+
+    # Test against the most up to date migration in the database;
+    # this should pass, i.e., not raise an exception.
     check_migration_version(engine)
 
+    # Back off to the previous migration.
     command.downgrade(alembic_config_left, '-1')
 
+    # Now the checker should raise an exception.
     with pytest.raises(ValueError):
         check_migration_version(engine)


### PR DESCRIPTION
This PR adds a function that checks the migration version of the database in use against the latest migration version in the repo. Resolves #57 .

Question: Should this function be invoked automatically when `pycds.Base.create_all()` is invoked? That would ensure all client code must be using a version-compatible release of PyCDS, but it may be too meddlesome. @jameshiebert ?

I'm tending toward "no" on this question, and it can easily be added in a later PR.