### PR TITLE
Add obs_raw indexes

### DIFF
--- a/pycds/alembic/env.py
+++ b/pycds/alembic/env.py
@@ -79,38 +79,33 @@ if is_live_env:
 def include_object(object, name, type_, reflected, compare_to):
     """Include only objects that belong to the specified schema."""
     if type_ == "table":
-        include = (not reflected and
-                   object.metadata.schema == target_metadata.schema)
-        print(f'include_object: '
-              f'name = {name} type_ = {type_}, '
-              f'reflected = {reflected}, '
-              f'schema = {object.metadata.schema}, '
-              f'include = {include}')
-        return include
+        object_schema = object.metadata.schema
     elif type_ == 'column':
-        include = (not reflected and
-                   object.table.metadata.schema == target_metadata.schema)
-        print(f'include_object: '
-              f'name = {name} type_ = {type_}, '
-              f'reflected = {reflected}, '
-              f'schema = {object.table.metadata.schema}, '
-              f'include = {include}')
-        return include
+        object_schema = object.table.metadata.schema
     elif type_ == 'index':
-        include = (not reflected and
-                   object.table.metadata.schema == target_metadata.schema)
-        print(f'include_object: '
-              f'name = {name} type_ = {type_}, '
-              f'reflected = {reflected}, '
-              f'schema = {object.table.metadata.schema}, '
-              f'include = {include}')
-        return include
+        object_schema = object.table.metadata.schema
+    elif type_ == 'foreign_key_constraint':
+        object_schema = object.table.metadata.schema
+    elif type_ == 'unique_constraint':
+        object_schema = object.table.metadata.schema
     else:
         print(f'include_object: '
+              f'Unknown object type'
               f'name = {name} type_ = {type_}, '
               f'reflected = {reflected}, '
-              f'include = {False}')
-        raise ValueError(f'Unexpected object type: {type_}')
+              f'object = {object}')
+        raise ValueError(f'Unknown object type: {type_}')
+
+    include = (not reflected and
+               object_schema == target_metadata.schema)
+    print(f'include_object: '
+          f'{"INCLUDE" if include else "EXCLUDE"} '
+          f'name = {name} type_ = {type_}, '
+          f'reflected = {reflected}, '
+          f'schema = {object_schema}, '
+          f'include = {include}')
+    return include
+
 
 
 def run_migrations_offline():

--- a/pycds/alembic/helpers.py
+++ b/pycds/alembic/helpers.py
@@ -50,3 +50,52 @@ def db_supports_matviews(engine):
     return db_supports_statement(
         engine, "CREATE MATERIALIZED VIEW test AS SELECT 1"
     )
+
+
+def get_schema_item_names(
+    executor, item_type, table_name=None, schema_name="crmp"
+):
+    if item_type == "routines":
+        r = executor.execute(
+            f"""
+            SELECT routine_name 
+            FROM information_schema.routines 
+            WHERE specific_schema = '{schema_name}'
+        """
+        )
+    elif item_type == "tables":
+        r = executor.execute(
+            f"""
+            SELECT table_name 
+            FROM information_schema.tables 
+            WHERE table_schema = '{schema_name}';
+        """
+        )
+    elif item_type == "views":
+        r = executor.execute(
+            f"""
+            SELECT table_name 
+            FROM information_schema.views 
+            WHERE table_schema = '{schema_name}';
+        """
+        )
+    elif item_type == "matviews":
+        r = executor.execute(
+            f"""
+            SELECT matviewname 
+            FROM pg_matviews
+            WHERE schemaname = '{schema_name}';
+        """
+        )
+    elif item_type == "indexes":
+        r = executor.execute(
+            f"""
+            SELECT indexname 
+            FROM pg_indexes
+            WHERE schemaname = '{schema_name}'
+            AND tablename = '{table_name}';
+        """
+        )
+    else:
+        raise ValueError("invalid item type")
+    return {x[0] for x in r.fetchall()}

--- a/pycds/alembic/versions/bdc28573df56_add_obs_raw_indexes.py
+++ b/pycds/alembic/versions/bdc28573df56_add_obs_raw_indexes.py
@@ -1,0 +1,61 @@
+"""Add obs_raw indexes
+
+Revision ID: bdc28573df56
+Revises: 7a3b247c577b
+Create Date: 2021-05-06 10:41:36.554301
+
+This migration conditionally creates/deletes the indexes. It is robust to
+their pre-existence on upgrade, and their non-existence on downgrade. The
+former is expected in some databases. It's hard to imagine why the latter
+would be true, but it's easy enough to provide for.
+"""
+import logging
+from alembic import op
+import sqlalchemy as sa
+from pycds import get_schema_name
+from pycds.alembic.helpers import get_schema_item_names
+
+
+# revision identifiers, used by Alembic.
+revision = "bdc28573df56"
+down_revision = "7a3b247c577b"
+branch_labels = None
+depends_on = None
+
+
+logger = logging.getLogger("alembic")
+schema_name = get_schema_name()
+
+
+indexes = (
+    ("mod_time_idx", "obs_raw", ["mod_time"]),
+    ("obs_raw_comp_idx", "obs_raw", ["obs_time", "vars_id", "history_id"]),
+    ("obs_raw_history_id_idx", "obs_raw", ["history_id"]),
+    ("obs_raw_id_idx", "obs_raw", ["obs_raw_id"]),
+)
+
+
+def upgrade():
+    engine = op.get_bind().engine
+    for index_name, table_name, columns in indexes:
+        existing_index_names = get_schema_item_names(
+            engine, "indexes", table_name=table_name, schema_name=schema_name
+        )
+        if index_name not in existing_index_names:
+            logger.debug(f"Creating index {index_name}")
+            op.create_index(index_name, table_name, columns, unique=False, schema=schema_name)
+        else:
+            logger.debug(f"Index {index_name} already exists; skipping create")
+
+
+def downgrade():
+    engine = op.get_bind().engine
+    for index_name, table_name, _ in indexes:
+        existing_index_names = get_schema_item_names(
+            engine, "indexes", table_name=table_name, schema_name=schema_name
+        )
+        if index_name in existing_index_names:
+            logger.debug(f"Dropping index {index_name}")
+            op.drop_index(index_name, table_name=table_name, schema=schema_name)
+        else:
+            logger.info(f"Index {index_name} does not exist; skipping drop")

--- a/pycds/util.py
+++ b/pycds/util.py
@@ -15,7 +15,7 @@ def check_migration_version(
     schema_name=get_schema_name(),
     # `version` must be kept up to date with latest migration
     # a test checks it, however, in case you don't
-    version="7a3b247c577b",
+    version="bdc28573df56",
 ):
     """Check that the migration version of the database schema is compatible
     with the current version of this package.

--- a/tests/alembic_migrations/test_migrations.py
+++ b/tests/alembic_migrations/test_migrations.py
@@ -48,6 +48,26 @@ def test_upgrade_and_downgrade(
         current = get_current_revision(alembic_config_left, engine, script)
 
 
+@pytest.mark.skip(reason="utility; not really a test")
+@pytest.mark.usefixtures('new_db_left')
+def test_indexes(
+    uri_left, alembic_config_left, db_setup, env_config,
+):
+    engine, script = prepare_schema_from_migrations(
+        uri_left, alembic_config_left, db_setup=db_setup
+    )
+
+    indexes = engine.execute("""
+        select indexname, indexdef 
+        from pg_indexes 
+        where schemaname ='crmp' 
+        order by indexname
+        """)
+    print(f"### indexes")
+    for index in indexes:
+        print(index[0], index[1])
+
+
 @pytest.mark.usefixtures('new_db_left')
 @pytest.mark.usefixtures('new_db_right')
 def test_model_and_migration_schemas_are_the_same(

--- a/tests/alembic_migrations/versions/v_bdc28573df56_add_obs_raw_indexes/conftest.py
+++ b/tests/alembic_migrations/versions/v_bdc28573df56_add_obs_raw_indexes/conftest.py
@@ -1,0 +1,47 @@
+import pytest
+from sqlalchemy.orm import sessionmaker
+from ...alembicverify_util import prepare_schema_from_migrations
+from ....helpers import insert_crmp_data
+
+
+@pytest.fixture(scope='function')
+def prepared_schema_from_migrations_left(
+    uri_left, alembic_config_left, db_setup,  mocker, request
+):
+    """
+    This fixture has an optional indirect parameter that determines
+    whether the helper function `get_schema_item_names` is mocked, and if so,
+    what its value is. Without an indirect parameter, the function is
+    unmocked and performs as usual. This allows us to test upgrade and downgrade
+    migrations in each case indexes present or not. Mocking must be done here
+    because fixtures are instantiated *before* the test is run, so it is
+    too late by the time we are inside the test.
+    """
+    if hasattr(request, "param"):
+        mocker.patch(
+            "pycds.alembic.helpers.get_schema_item_names",
+            return_value=request.param
+        )
+
+    engine, script = prepare_schema_from_migrations(
+        uri_left,
+        alembic_config_left,
+        db_setup=db_setup,
+        revision="bdc28573df56"
+    )
+
+    yield engine, script
+
+    engine.dispose()
+
+
+@pytest.fixture(scope='function')
+def sesh_with_large_data(prepared_schema_from_migrations_left):
+    # TODO: Is large data needed??
+    engine, script = prepared_schema_from_migrations_left
+    sesh = sessionmaker(bind=engine)()
+    insert_crmp_data(sesh)
+
+    yield sesh
+
+    sesh.close()

--- a/tests/alembic_migrations/versions/v_bdc28573df56_add_obs_raw_indexes/test_smoke.py
+++ b/tests/alembic_migrations/versions/v_bdc28573df56_add_obs_raw_indexes/test_smoke.py
@@ -1,0 +1,111 @@
+"""Smoke tests:
+- Upgrade adds indexes
+- Downgrade drops indexes
+"""
+
+# -*- coding: utf-8 -*-
+import logging
+import pytest
+from alembic import command
+from ....helpers import get_schema_item_names
+import pycds.alembic.helpers
+
+
+logger = logging.getLogger("tests")
+
+
+index_names = {
+    "mod_time_idx",
+    "obs_raw_comp_idx",
+    "obs_raw_history_id_idx",
+    "obs_raw_id_idx",
+}
+
+
+@pytest.mark.parametrize("item_names", [set(), {"alpha", "beta"}])
+def test_mock(mocker, item_names):
+    mocker.patch(
+        "pycds.alembic.helpers.get_schema_item_names", return_value=item_names
+    )
+    assert pycds.alembic.helpers.get_schema_item_names() == item_names
+
+
+@pytest.mark.parametrize(
+    # We need the values of the mocked prior index names for the test
+    # assertions. However, it's not convenient to get it in advance of running
+    # the migration. Therefore we supply it direct. Inelegant but workable.
+    "prepared_schema_from_migrations_left, prior_index_names",
+    [(set(),) * 2, (index_names,) * 2],
+    indirect=["prepared_schema_from_migrations_left"],
+)
+@pytest.mark.usefixtures("new_db_left")
+def test_upgrade(
+    prepared_schema_from_migrations_left, prior_index_names, schema_name
+):
+    """Test the schema migration from 7a3b247c577b to bdc28573df56. """
+
+    # Set up database to revision bdc28573df56
+    engine, script = prepared_schema_from_migrations_left
+
+    # Check that indexes have been added
+    after_upgrade_index_names = get_schema_item_names(
+        engine, "indexes", table_name="obs_raw", schema_name=schema_name
+    )
+    assert index_names <= prior_index_names | after_upgrade_index_names
+
+
+@pytest.mark.usefixtures("prepared_schema_from_migrations_left")
+@pytest.mark.usefixtures("new_db_left")
+@pytest.mark.parametrize("prior_index_names", [set(), index_names])
+def test_downgrade(
+    prepared_schema_from_migrations_left,
+    prior_index_names,
+    alembic_config_left,
+    schema_name,
+    mocker,
+):
+    """
+    Test the schema migration from bdc28573df56 to 7a3b247c577b.
+
+    If we mock the new indexes as already existing before schema is prepared
+    (i.e., before the upgrade happens), then the upgrade operation won't
+    add them, and they won't actually exist in the database because they are
+    only mocked to pre-exist. The downgrade operation will then try to remove
+    these existing indexes, but fail because they were never actually there.
+
+    Solution: Don't mock the pre-existing indexes until *after* the upgrade
+    has added them. Then check whether, depending on what was mocked, they
+    have been removed or left in place. This is the obverse of the reason
+    that fixture can pre-mock the existing indexes.
+    """
+
+    # Set up database to revision bdc28573df56
+    engine, script = prepared_schema_from_migrations_left
+
+    # Tell the downgrade operation what we want it to think.
+    patcher = mocker.patch(
+        "pycds.alembic.helpers.get_schema_item_names",
+        return_value=prior_index_names,
+    )
+
+    # Run downgrade migration to revision 7a3b247c577b
+    command.downgrade(alembic_config_left, "-1")
+
+    # Stop mocking; now we can see what's actually in the database.
+    patcher.stop()
+
+    # Check that indexes have been removed according to mocked values
+    after_downgrade_index_names = get_schema_item_names(
+        engine, "indexes", table_name="obs_raw", schema_name=schema_name
+    )
+    # This could be expressed as
+    # index_names <= prior_index_names.symmetric_difference(after_downgrade_index_names)
+    # but the following is clearer:
+    for name in index_names:
+        assert (
+            name in prior_index_names
+            and name not in after_downgrade_index_names
+        ) or (
+            name not in prior_index_names
+            and name in after_downgrade_index_names
+        )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 from datetime import datetime
 
 from pycds import get_schema_name, Contact, Network, Station, History, Variable
-
+from pycds.alembic.helpers import get_schema_item_names
 
 # Fixture helpers
 
@@ -199,42 +199,3 @@ def insert_crmp_data(sesh, schema_name=get_schema_name()):
         sesh.execute(data)
 
     with_schema_name(sesh, schema_name, action)
-
-
-# Test helpers
-
-def get_schema_item_names(executor, item_type, table_name=None, schema_name=get_schema_name()):
-    if item_type == 'routines':
-        r = executor.execute(f"""
-            SELECT routine_name 
-            FROM information_schema.routines 
-            WHERE specific_schema = '{schema_name}'
-        """)
-    elif item_type == 'tables':
-        r = executor.execute(f"""
-            SELECT table_name 
-            FROM information_schema.tables 
-            WHERE table_schema = '{schema_name}';
-        """)
-    elif item_type == 'views':
-        r = executor.execute(f"""
-            SELECT table_name 
-            FROM information_schema.views 
-            WHERE table_schema = '{schema_name}';
-        """)
-    elif item_type == 'matviews':
-        r = executor.execute(f"""
-            SELECT matviewname 
-            FROM pg_matviews
-            WHERE schemaname = '{schema_name}';
-        """)
-    elif item_type == 'indexes':
-        r = executor.execute(f"""
-            SELECT indexname 
-            FROM pg_indexes
-            WHERE schemaname = '{schema_name}'
-            AND tablename = '{table_name}';
-        """)
-    else:
-        raise ValueError('invalid item type')
-    return {x[0] for x in r.fetchall()}


### PR DESCRIPTION
As a partial address to #87 , add the following indexes.

- `mod_time_idx`
- `obs_raw_comp_idx`
- `obs_raw_history_id_idx`
- `obs_raw_id_idx`

The new revision follows 7a3b247c577b (current head).

| Index | ORM | Revision | Verification |
|----|----|----|----|
| `mod_time_idx`            | x  | x  |  |
| `obs_raw_comp_idx`        | x  | x  |  |
| `obs_raw_history_id_idx`  | x  | x  |  |
| `obs_raw_id_idx`          | x  | x  |  |