### PR TITLE
Fix copy-conflict warnings

### DIFF
--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -148,8 +148,9 @@ class History(Base):
         "Station", backref=backref("meta_history", order_by=id)
     )
     observations = relationship(
-        "Obs", backref=backref("meta_history", order_by=id)
+        "Obs", back_populates="history", order_by="Obs.id"
     )
+    obs_raw = synonym("observations")  # Retain backwards compatibility
 
 
 Index("fki_meta_history_station_id_fk", History.station_id)
@@ -212,7 +213,10 @@ class Obs(Base):
     history_id = Column(Integer, ForeignKey("meta_history.history_id"))
 
     # Relationships
-    history = relationship("History", backref=backref("obs_raw", order_by=id))
+    history = relationship(
+        "History", back_populates="observations"
+    )
+    meta_history = synonym("history")  # Retain backwards compatibility
     variable = relationship("Variable", back_populates="obs")
     meta_vars = synonym("variable")  # To keep backwards compatibility
     flags = relationship(

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -159,13 +159,9 @@ class History(Base):
     sensor = relationship("MetaSensor")
     station = relationship("Station", back_populates="histories")
     meta_station = synonym("station")  # Retain backwards compatibility
-    observations = relationship(
-        "Obs", order_by="Obs.id", back_populates="history"
-    )
+    observations = relationship("Obs", back_populates="history")
     obs_raw = synonym("observations")  # Retain backwards compatibility
-    derived_values = relationship(
-        "DerivedValue", order_by="DerivedValue.id", back_populates="history"
-    )
+    derived_values = relationship("DerivedValue", back_populates="history")
     obs_derived_values = synonym("derived_values")  # Backwards compatibility
 
 
@@ -295,12 +291,10 @@ class Variable(Base):
     # Relationships
     network = relationship("Network", back_populates="variables")
     meta_network = synonym("network")
-    obs = relationship("Obs", order_by="Obs.id", back_populates="variable")
+    obs = relationship("Obs", back_populates="variable")
     observations = synonym("obs")  # Better name
     obs_raw = synonym("obs")  # To keep backwards compatibility
-    derived_values = relationship(
-        "DerivedValue", order_by="DerivedValue.id", back_populates="variable"
-    )
+    derived_values = relationship("DerivedValue", back_populates="variable")
     obs_derived_values = synonym("derived_values")  # Backwards compatibility
 
     def __repr__(self):

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -9,7 +9,7 @@ ORM class via `ORMClass.__table__.indexes`. The latter is very convenient, so
 we make sure always to declare indexes outside of classes. See code below for
 many examples.
 
-2. Relationships should be declared using `back_populates=`, and *not* using
+2. We prefer to declare relationships using `back_populates=`, *not* using
 `backref=`. Using `back_populates` is slightly redundant, but the redundancy
 ensures that each class explicitly names all its relationship attributes.
 (Using `backref` requires one to scan the all other classes to

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -58,6 +58,8 @@ class Network(Base):
     meta_station = synonym("stations")
     variables = relationship("Variable", back_populates="network")
     meta_vars = synonym("variables")
+    contact = relationship("Contact", back_populates="networks")
+    meta_contact = synonym("contact")  # Retain backwards compatibility
 
     def __str__(self):
         return "<CRMP Network %s>" % self.name
@@ -78,7 +80,7 @@ class Contact(Base):
     phone = Column("phone", String)
 
     networks = relationship(
-        "Network", backref=backref("meta_contact", order_by=id)
+        "Network", order_by="Network.id", back_populates="contact"
     )
 
 

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -8,6 +8,12 @@ paradoxically not included in the internal list of indexes available for an
 ORM class via `ORMClass.__table__.indexes`. The latter is very convenient, so
 we make sure always to declare indexes outside of classes. See code below for
 many examples.
+
+2. Relationships should be declared using `back_populates=`, and *not* using
+`backref=`. Using `back_populates` is slightly redundant, but the redundancy
+ensures that each class explicitly names all its relationship attributes.
+(Using `backref` requires one to scan the all other classes to
+find all the relationship attributes that a given class may have.)
 """
 
 import datetime
@@ -24,9 +30,9 @@ from sqlalchemy import (
     Index,
 )
 from sqlalchemy import DateTime, Boolean, ForeignKey, Numeric, Interval
-from sqlalchemy.ext.declarative import declarative_base, DeferredReflection
-from sqlalchemy.orm import relationship, backref, synonym
-from sqlalchemy.schema import DDL, UniqueConstraint
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship, synonym
+from sqlalchemy.schema import UniqueConstraint
 from geoalchemy2 import Geometry
 
 from pycds.context import get_schema_name
@@ -223,9 +229,7 @@ class Obs(Base):
     history_id = Column(Integer, ForeignKey("meta_history.history_id"))
 
     # Relationships
-    history = relationship(
-        "History", back_populates="observations"
-    )
+    history = relationship("History", back_populates="observations")
     meta_history = synonym("history")  # Retain backwards compatibility
     variable = relationship("Variable", back_populates="obs")
     meta_vars = synonym("variable")  # To keep backwards compatibility
@@ -289,9 +293,7 @@ class Variable(Base):
     network_id = Column(Integer, ForeignKey("meta_network.network_id"))
 
     # Relationships
-    network = relationship(
-        "Network", back_populates="variables"
-    )
+    network = relationship("Network", back_populates="variables")
     meta_network = synonym("network")
     obs = relationship("Obs", order_by="Obs.id", back_populates="variable")
     observations = synonym("obs")  # Better name
@@ -299,7 +301,7 @@ class Variable(Base):
     derived_values = relationship(
         "DerivedValue", order_by="DerivedValue.id", back_populates="variable"
     )
-    obs_derived_values = synonym("derived_values") # Backwards compatibility
+    obs_derived_values = synonym("derived_values")  # Backwards compatibility
 
     def __repr__(self):
         return "<{} id={id} name='{name}' standard_name='{standard_name}' cell_method='{cell_method}' network_id={network_id}>".format(
@@ -311,9 +313,10 @@ Index("fki_meta_vars_network_id_fkey", Variable.network_id)
 
 
 class NativeFlag(Base):
-    """This class maps to the table which records all 'flags' for observations which have been `flagged` by the
-    data provider (i.e. the network) for some reason. This table records the details of the flags.
-    Actual flagging is recorded in the class/table ObsRawNativeFlags.
+    """This class maps to the table which records all 'flags' for observations
+    which have been `flagged` by the data provider (i.e. the network) for some
+    reason. This table records the details of the flags. Actual flagging is
+    recorded in the class/table ObsRawNativeFlags.
     """
 
     __tablename__ = "meta_native_flag"
@@ -336,9 +339,10 @@ class NativeFlag(Base):
 
 
 class PCICFlag(Base):
-    """This class maps to the table which records all 'flags' for observations which have been flagged by PCIC
-    for some reason. This table records the details of the flags.
-    Actual flagging is recorded in the class/table ObsRawNativeFlags.
+    """This class maps to the table which records all 'flags' for observations
+    which have been flagged by PCIC for some reason. This table records the
+    details of the flags. Actual flagging is recorded in the class/table
+    ObsRawPCICFlags.
     """
 
     __tablename__ = "meta_pcic_flag"

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -292,6 +292,10 @@ class Variable(Base):
     obs = relationship("Obs", order_by="Obs.id", back_populates="variable")
     observations = synonym("obs")  # Better name
     obs_raw = synonym("obs")  # To keep backwards compatibility
+    derived_values = relationship(
+        "DerivedValue", order_by="DerivedValue.id", back_populates="variable"
+    )
+    obs_derived_values = synonym("derived_values") # Backwards compatibility
 
     def __repr__(self):
         return "<{} id={id} name='{name}' standard_name='{standard_name}' cell_method='{cell_method}' network_id={network_id}>".format(
@@ -352,9 +356,7 @@ class DerivedValue(Base):
 
     # Relationships
     history = relationship("History", back_populates="derived_values")
-    variable = relationship(
-        "Variable", backref=backref("obs_derived_values", order_by=id)
-    )
+    variable = relationship("Variable", back_populates="derived_values")
 
     # Constraints
     __table_args__ = (

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -60,6 +60,10 @@ class Network(Base):
     meta_vars = synonym("variables")
     contact = relationship("Contact", back_populates="networks")
     meta_contact = synonym("contact")  # Retain backwards compatibility
+    native_flags = relationship(
+        "NativeFlag", order_by="NativeFlag.id", back_populates="network"
+    )
+    meta_native_flag = synonym("native_flags")  # Retain backwards compatibility
 
     def __str__(self):
         return "<CRMP Network %s>" % self.name
@@ -320,9 +324,7 @@ class NativeFlag(Base):
     value = Column(String)
     discard = Column(Boolean)
 
-    network = relationship(
-        "Network", backref=backref("meta_native_flag", order_by=id)
-    )
+    network = relationship("Network", back_populates="native_flags")
     flagged_obs = relationship(
         "Obs", secondary=ObsRawNativeFlags, back_populates="native_flags"
     )

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -100,8 +100,9 @@ class Station(Base):
         "Network", backref=backref("meta_station", order_by=id)
     )
     histories = relationship(
-        "History", backref=backref("meta_station", order_by=id)
+        "History", back_populates="station", order_by=id
     )
+    meta_history = synonym("histories")  # Retain backwards compatibility
 
     def __str__(self):
         return "<CRMP Station %s:%s>" % (self.network.name, self.native_id)
@@ -144,9 +145,8 @@ class History(Base):
 
     # Relationships
     sensor = relationship("MetaSensor")
-    station = relationship(
-        "Station", backref=backref("meta_history", order_by=id)
-    )
+    station = relationship("Station", back_populates="histories")
+    meta_station = synonym("station")  # Retain backwards compatibility
     observations = relationship(
         "Obs", back_populates="history", order_by="Obs.id"
     )

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -218,8 +218,7 @@ class Obs(Base):
     flags = relationship(
         "NativeFlag", secondary=ObsRawNativeFlags, backref="flagged_obs"
     )
-    # better named alias for 'flags'; don't repeat backref
-    native_flags = relationship("NativeFlag", secondary=ObsRawNativeFlags)
+    native_flags = synonym("flags")  # Better name
     pcic_flags = relationship(
         "PCICFlag", secondary=ObsRawPCICFlags, backref="flagged_obs"
     )

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -230,7 +230,7 @@ class Obs(Base):
     )
     flags = synonym("native_flags")  # Retain backwards compatibility
     pcic_flags = relationship(
-        "PCICFlag", secondary=ObsRawPCICFlags, backref="flagged_obs"
+        "PCICFlag", secondary=ObsRawPCICFlags, back_populates="flagged_obs"
     )
 
     # Constraints
@@ -344,6 +344,10 @@ class PCICFlag(Base):
     name = Column("flag_name", String)
     description = Column(String)
     discard = Column(Boolean)
+
+    flagged_obs = relationship(
+        "Obs", secondary=ObsRawPCICFlags, back_populates="pcic_flags"
+    )
 
 
 class DerivedValue(Base):

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -153,6 +153,10 @@ class History(Base):
         "Obs", order_by="Obs.id", back_populates="history"
     )
     obs_raw = synonym("observations")  # Retain backwards compatibility
+    derived_values = relationship(
+        "DerivedValue", order_by="DerivedValue.id", back_populates="history"
+    )
+    obs_derived_values = synonym("derived_values")  # Backwards compatibility
 
 
 Index("fki_meta_history_station_id_fk", History.station_id)
@@ -347,9 +351,7 @@ class DerivedValue(Base):
     history_id = Column(Integer, ForeignKey("meta_history.history_id"))
 
     # Relationships
-    history = relationship(
-        "History", backref=backref("obs_derived_values", order_by=id)
-    )
+    history = relationship("History", back_populates="derived_values")
     variable = relationship(
         "Variable", backref=backref("obs_derived_values", order_by=id)
     )

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -53,8 +53,9 @@ class Network(Base):
     contact_id = Column(Integer, ForeignKey("meta_contact.contact_id"))
 
     stations = relationship(
-        "Station", backref=backref("meta_network", order_by=id)
+        "Station", back_populates="network", order_by="Network.id"
     )
+    meta_station = synonym("stations")
     variables = relationship("Variable", back_populates="network")
     meta_vars = synonym("variables")
 
@@ -96,9 +97,8 @@ class Station(Base):
     max_obs_time = Column(DateTime)
 
     # Relationships
-    network = relationship(
-        "Network", backref=backref("meta_station", order_by=id)
-    )
+    network = relationship("Network", back_populates="stations")
+    meta_network = synonym("network")
     histories = relationship(
         "History", back_populates="station", order_by=id
     )

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -225,10 +225,10 @@ class Obs(Base):
     meta_history = synonym("history")  # Retain backwards compatibility
     variable = relationship("Variable", back_populates="obs")
     meta_vars = synonym("variable")  # To keep backwards compatibility
-    flags = relationship(
-        "NativeFlag", secondary=ObsRawNativeFlags, backref="flagged_obs"
+    native_flags = relationship(
+        "NativeFlag", secondary=ObsRawNativeFlags, back_populates="flagged_obs"
     )
-    native_flags = synonym("flags")  # Better name
+    flags = synonym("native_flags")  # Retain backwards compatibility
     pcic_flags = relationship(
         "PCICFlag", secondary=ObsRawPCICFlags, backref="flagged_obs"
     )
@@ -322,6 +322,9 @@ class NativeFlag(Base):
 
     network = relationship(
         "Network", backref=backref("meta_native_flag", order_by=id)
+    )
+    flagged_obs = relationship(
+        "Obs", secondary=ObsRawNativeFlags, back_populates="native_flags"
     )
 
     # Constraints

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -25,7 +25,7 @@ from sqlalchemy import (
 )
 from sqlalchemy import DateTime, Boolean, ForeignKey, Numeric, Interval
 from sqlalchemy.ext.declarative import declarative_base, DeferredReflection
-from sqlalchemy.orm import relationship, backref
+from sqlalchemy.orm import relationship, backref, synonym
 from sqlalchemy.schema import DDL, UniqueConstraint
 from geoalchemy2 import Geometry
 
@@ -214,7 +214,8 @@ class Obs(Base):
 
     # Relationships
     history = relationship("History", backref=backref("obs_raw", order_by=id))
-    variable = relationship("Variable", backref=backref("obs_raw", order_by=id))
+    variable = relationship("Variable", back_populates="obs")
+    meta_vars = synonym("variable")  # To keep backwards compatibility
     flags = relationship(
         "NativeFlag", secondary=ObsRawNativeFlags, backref="flagged_obs"
     )
@@ -277,7 +278,8 @@ class Variable(Base):
 
     # Relationships
     network = relationship("Network", backref=backref("meta_vars", order_by=id))
-    obs = relationship("Obs", backref=backref("meta_vars", order_by=id))
+    obs = relationship("Obs", back_populates="variable", order_by="Obs.id")
+    obs_raw = synonym("obs")  # To keep backwards compatibility
 
     def __repr__(self):
         return "<{} id={id} name='{name}' standard_name='{standard_name}' cell_method='{cell_method}' network_id={network_id}>".format(

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -55,9 +55,8 @@ class Network(Base):
     stations = relationship(
         "Station", backref=backref("meta_network", order_by=id)
     )
-    variables = relationship(
-        "Variable", backref=backref("meta_network", order_by=id)
-    )
+    variables = relationship("Variable", back_populates="network")
+    meta_vars = synonym("variables")
 
     def __str__(self):
         return "<CRMP Network %s>" % self.name
@@ -277,7 +276,10 @@ class Variable(Base):
     network_id = Column(Integer, ForeignKey("meta_network.network_id"))
 
     # Relationships
-    network = relationship("Network", backref=backref("meta_vars", order_by=id))
+    network = relationship(
+        "Network", back_populates="variables", order_by="Variable.id"
+    )
+    meta_network = synonym("network")
     obs = relationship("Obs", back_populates="variable", order_by="Obs.id")
     obs_raw = synonym("obs")  # To keep backwards compatibility
 

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -53,7 +53,7 @@ class Network(Base):
     contact_id = Column(Integer, ForeignKey("meta_contact.contact_id"))
 
     stations = relationship(
-        "Station", back_populates="network", order_by="Network.id"
+        "Station", order_by="Station.id", back_populates="network"
     )
     meta_station = synonym("stations")
     variables = relationship("Variable", back_populates="network")
@@ -100,7 +100,7 @@ class Station(Base):
     network = relationship("Network", back_populates="stations")
     meta_network = synonym("network")
     histories = relationship(
-        "History", back_populates="station", order_by=id
+        "History", order_by="History.id", back_populates="station"
     )
     meta_history = synonym("histories")  # Retain backwards compatibility
 
@@ -148,7 +148,7 @@ class History(Base):
     station = relationship("Station", back_populates="histories")
     meta_station = synonym("station")  # Retain backwards compatibility
     observations = relationship(
-        "Obs", back_populates="history", order_by="Obs.id"
+        "Obs", order_by="Obs.id", back_populates="history"
     )
     obs_raw = synonym("observations")  # Retain backwards compatibility
 
@@ -280,10 +280,11 @@ class Variable(Base):
 
     # Relationships
     network = relationship(
-        "Network", back_populates="variables", order_by="Variable.id"
+        "Network", back_populates="variables"
     )
     meta_network = synonym("network")
-    obs = relationship("Obs", back_populates="variable", order_by="Obs.id")
+    obs = relationship("Obs", order_by="Obs.id", back_populates="variable")
+    observations = synonym("obs")  # Better name
     obs_raw = synonym("obs")  # To keep backwards compatibility
 
     def __repr__(self):

--- a/tests/alembic_migrations/conftest.py
+++ b/tests/alembic_migrations/conftest.py
@@ -35,6 +35,14 @@ def uri_right(base_database_uri):
 
 @pytest.fixture(scope="module")
 def db_setup(schema_name):
+    """
+    Database setup operations. These are operations that must executed prior
+    to the creation of any (other) content in the database in order for the
+    tests to work.
+
+    The function returned by this fixture is passed to
+    `alembicverify_util.prepare_schema_from_migrations`, which invokes it.
+    """
     def f(engine):
         test_user = "testuser"
 
@@ -79,6 +87,14 @@ def db_setup(schema_name):
 
 @pytest.fixture(scope="module")
 def env_config(schema_name):
+    """
+    Additional Alembic migration environment configuration values. These
+    values are required for the tests to operate properly; in particular for
+    them to respect the schema the migrations are being applied to.
+
+    These values are passed to `alembicverify_util.get_current_revision`,
+    `.get_head_revision` as kw args of the same name.
+    """
     return {
         "version_table": "alembic_version",
         "version_table_schema": schema_name,

--- a/tests/alembic_migrations/test_check_migration_version.py
+++ b/tests/alembic_migrations/test_check_migration_version.py
@@ -11,9 +11,7 @@ def test_get_current_head():
 
 
 @pytest.mark.usefixtures("new_db_left")
-def test_check_migration_version(
-    uri_left, alembic_config_left, db_setup, env_config
-):
+def test_check_migration_version(uri_left, alembic_config_left, db_setup):
     """Test that `check_migration_version` passes on the latest migration
     and raises an exception on other versions.
 

--- a/tests/alembic_migrations/test_migrations.py
+++ b/tests/alembic_migrations/test_migrations.py
@@ -48,7 +48,7 @@ def test_upgrade_and_downgrade(
 
 @pytest.mark.skip(reason="utility; not really a test")
 @pytest.mark.usefixtures("new_db_left")
-def test_indexes(uri_left, alembic_config_left, db_setup, env_config):
+def test_indexes(uri_left, alembic_config_left, db_setup):
     engine, script = prepare_schema_from_migrations(
         uri_left, alembic_config_left, db_setup=db_setup
     )

--- a/tests/alembic_migrations/test_warnings.py
+++ b/tests/alembic_migrations/test_warnings.py
@@ -19,4 +19,3 @@ def test_warnings(
             print(f"\n{w}")
         assert len(ws) == 0
         assert all(w.category == SAWarning for w in ws)
-

--- a/tests/alembic_migrations/test_warnings.py
+++ b/tests/alembic_migrations/test_warnings.py
@@ -1,0 +1,22 @@
+import warnings
+import pytest
+
+from sqlalchemy.exc import SAWarning
+from .alembicverify_util import prepare_schema_from_migrations
+
+
+@pytest.mark.usefixtures("new_db_left")
+def test_warnings(
+    uri_left, alembic_config_left, db_setup, env_config
+):
+    with warnings.catch_warnings(record=True) as ws:
+        warnings.simplefilter("always")
+        engine, script = prepare_schema_from_migrations(
+            uri_left, alembic_config_left, db_setup=db_setup
+        )
+        print(f"{len(ws)} warnings:")
+        for w in ws:
+            print(f"\n{w}")
+        assert len(ws) == 12
+        assert all(w.category == SAWarning for w in ws)
+

--- a/tests/alembic_migrations/test_warnings.py
+++ b/tests/alembic_migrations/test_warnings.py
@@ -6,9 +6,7 @@ from .alembicverify_util import prepare_schema_from_migrations
 
 
 @pytest.mark.usefixtures("new_db_left")
-def test_warnings(
-    uri_left, alembic_config_left, db_setup, env_config
-):
+def test_warnings(uri_left, alembic_config_left, db_setup):
     with warnings.catch_warnings(record=True) as ws:
         warnings.simplefilter("always")
         engine, script = prepare_schema_from_migrations(

--- a/tests/alembic_migrations/test_warnings.py
+++ b/tests/alembic_migrations/test_warnings.py
@@ -17,6 +17,6 @@ def test_warnings(
         print(f"{len(ws)} warnings:")
         for w in ws:
             print(f"\n{w}")
-        assert len(ws) == 8
+        assert len(ws) == 6
         assert all(w.category == SAWarning for w in ws)
 

--- a/tests/alembic_migrations/test_warnings.py
+++ b/tests/alembic_migrations/test_warnings.py
@@ -14,8 +14,9 @@ def test_warnings(
         engine, script = prepare_schema_from_migrations(
             uri_left, alembic_config_left, db_setup=db_setup
         )
-        print(f"{len(ws)} warnings:")
-        for w in ws:
-            print(f"\n{w}")
+        # When warnings are present and being addressed, these print statements
+        # are useful.
+        # print(f"{len(ws)} warnings:")
+        # for w in ws:
+        #     print(f"\n{w}")
         assert len(ws) == 0
-        assert all(w.category == SAWarning for w in ws)

--- a/tests/alembic_migrations/test_warnings.py
+++ b/tests/alembic_migrations/test_warnings.py
@@ -17,6 +17,6 @@ def test_warnings(
         print(f"{len(ws)} warnings:")
         for w in ws:
             print(f"\n{w}")
-        assert len(ws) == 10
+        assert len(ws) == 8
         assert all(w.category == SAWarning for w in ws)
 

--- a/tests/alembic_migrations/test_warnings.py
+++ b/tests/alembic_migrations/test_warnings.py
@@ -17,6 +17,6 @@ def test_warnings(
         print(f"{len(ws)} warnings:")
         for w in ws:
             print(f"\n{w}")
-        assert len(ws) == 12
+        assert len(ws) == 10
         assert all(w.category == SAWarning for w in ws)
 

--- a/tests/alembic_migrations/test_warnings.py
+++ b/tests/alembic_migrations/test_warnings.py
@@ -17,6 +17,6 @@ def test_warnings(
         print(f"{len(ws)} warnings:")
         for w in ws:
             print(f"\n{w}")
-        assert len(ws) == 4
+        assert len(ws) == 2
         assert all(w.category == SAWarning for w in ws)
 

--- a/tests/alembic_migrations/test_warnings.py
+++ b/tests/alembic_migrations/test_warnings.py
@@ -17,6 +17,6 @@ def test_warnings(
         print(f"{len(ws)} warnings:")
         for w in ws:
             print(f"\n{w}")
-        assert len(ws) == 6
+        assert len(ws) == 4
         assert all(w.category == SAWarning for w in ws)
 

--- a/tests/alembic_migrations/test_warnings.py
+++ b/tests/alembic_migrations/test_warnings.py
@@ -17,6 +17,6 @@ def test_warnings(
         print(f"{len(ws)} warnings:")
         for w in ws:
             print(f"\n{w}")
-        assert len(ws) == 2
+        assert len(ws) == 0
         assert all(w.category == SAWarning for w in ws)
 


### PR DESCRIPTION
Resolves #94 

This PR fixes the code that gives rise to the warnings, as noted in #94. It also converts all other relationship declarations to the symmetric, explicit `back_populates` style we now prefer.