### PR TITLE
Pin zipp dependency to "==3.5.0"

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -38,7 +38,7 @@ pluggy = "==0.13.0"
 six = "==1.12.0"
 sqlalchemy-diff = "==0.1.5"
 SQLAlchemy-Utils = "==0.37.3"
-zipp = "==0.6.0"
+zipp = "==3.5.0"
 
 # We can't use python_version because with a Ubuntu 18.04 base image
 # (which we must use in order to access old versions of Postgres etc.),

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c327669cfc7bd8c8bfac22750da23472dfc6550a864329c202a00e6001f2a964"
+            "sha256": "2abc85c6431bb0a65d0ed01cf7370efd6d0e60950ca01c7f72beb0d4c44102cf"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -450,6 +450,14 @@
             "index": "pypi",
             "version": "==0.23"
         },
+        "importlib-resources": {
+            "hashes": [
+                "sha256:2480d8e07d1890056cb53c96e3de44fead9c62f2ba949b0f2e4c4345f4afa977",
+                "sha256:a65882a4d0fe5fbf702273456ba2ce74fe44892c25e42e057aca526b702a6d4b"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==5.2.2"
+        },
         "mako": {
             "hashes": [
                 "sha256:a36919599a9b7dc5d86a7a8988f23a9a3a3d083070023bab23d64f7f1d1e0a4b"
@@ -570,25 +578,6 @@
             "index": "pypi",
             "version": "==3.2.0"
         },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
-                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
-            ],
-            "index": "pypi",
-            "version": "==2.8.0"
-        },
-        "python-editor": {
-            "hashes": [
-                "sha256:1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d",
-                "sha256:51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b",
-                "sha256:5f98b069316ea1c2ed3f67e7f5df6c0d8f10b689964a4a811ff64f0106819ec8",
-                "sha256:c3da2053dbab6b29c94e43c486ff67206eafbe7eb52dbec7390b5e2fb05aac77",
-                "sha256:ea87e17f6ec459e780e4221f295411462e0d0810858e055fc514684350a2f522"
-            ],
-            "index": "pypi",
-            "version": "==1.0.4"
-        },
         "scramp": {
             "hashes": [
                 "sha256:475aa6296deb2737b86e9df9098e8eca0f30c8ad1cc0a8adadb99ef012a5ceba",
@@ -674,11 +663,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
-                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
+                "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3",
+                "sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4"
             ],
             "index": "pypi",
-            "version": "==0.6.0"
+            "version": "==3.5.0"
         }
     }
 }


### PR DESCRIPTION
An external change in the dependencies of this project introduced a requirement for `zipp>=3.5.0`, causing the current installation to fail on a version conflict. The package that introduced this change is unknown; `pipenv graph` does not indicate where the requirement comes from. Updating the `Pipfile` to this requirement fixes the problem. 