### PR TITLE
Add crmp2 and update migrations to accommodate crmp database idiosyncracies

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -52,6 +52,9 @@ sqlalchemy.url = postgresql://metnorth@dbnorth.pcic.uvic.ca/metnorth
 [crmp_test]
 sqlalchemy.url = postgresql://crmp_test@monsoon.pcic.uvic.ca/crmp_test
 
+[crmp2_test]
+sqlalchemy.url = postgresql://crmp@dbtest01.pcic.uvic.ca/crmp2
+
 [crmp_prod]
 sqlalchemy.url = postgresql://crmp@monsoon.pcic.uvic.ca/crmp
 

--- a/pycds/alembic/extensions/operation_plugins.py
+++ b/pycds/alembic/extensions/operation_plugins.py
@@ -33,9 +33,10 @@ class DropTableIfExistsOp(MigrateOperation):
     TODO: Inherit from Alembic builtin DropTableOp? See DropConstraintIfExistsOp
     """
 
-    def __init__(self, name, schema=None):
+    def __init__(self, name, schema=None, cascade=False):
         self.name = name
         self.schema = schema
+        self.cascade = cascade
 
     @classmethod
     def drop_table_if_exists(cls, operations, name, **kw):
@@ -59,8 +60,16 @@ class DropTableIfExistsOp(MigrateOperation):
 @Operations.implementation_for(DropTableIfExistsOp)
 def drop_table_if_exists(operations, operation):
     # TODO: Refactor into a DDL extension.
+    # TODO: Possibly refactor this into a command DropTableWithOptions to accommodate
+    #   the possibility of omitting IF EXISTS and adding other options like CASCADE
     schema_prefix = f"{operation.schema}." if operation.schema is not None else ""
-    operations.execute(f"DROP TABLE IF EXISTS {schema_prefix}{operation.name}")
+    command_parts = [
+        "DROP TABLE",
+        "IF EXISTS",
+        f"{schema_prefix}{operation.name}",
+        operation.cascade and "CASCADE"
+    ]
+    operations.execute(" ".join(filter(None, command_parts)))
 
 
 @Operations.register_operation("drop_constraint_if_exists")

--- a/pycds/alembic/extensions/operation_plugins.py
+++ b/pycds/alembic/extensions/operation_plugins.py
@@ -67,7 +67,7 @@ def drop_table_if_exists(operations, operation):
         "DROP TABLE",
         "IF EXISTS",
         f"{schema_prefix}{operation.name}",
-        operation.cascade and "CASCADE"
+        operation.cascade and "CASCADE",
     ]
     operations.execute(" ".join(filter(None, command_parts)))
 
@@ -95,8 +95,12 @@ class DropConstraintIfExistsOp(DropConstraintOp):
         )
 
     @classmethod
-    def batch_drop_constraint_if_exists(cls, operations, constraint_name, type_=None):
-        return cls.drop_constraint(operations, constraint_name, type_=type_)
+    def batch_drop_constraint_if_exists(
+        cls, operations, constraint_name, table_name, type_=None, schema=None
+    ):
+        return cls.drop_constraint(
+            operations, constraint_name, table_name, type_=type_, schema=schema
+        )
 
 
 @Operations.implementation_for(DropConstraintIfExistsOp)


### PR DESCRIPTION
UPDATE: 

The idiosyncrasies mentioned are that CRMP has a number of views and matviews not managed by PyCDS that depend on tables that are. 

Originally, the intention was to drop-cascade the views in question; that later seemed out not to be a good idea but the cascade option is now available for other uses. No migration was modified to make use of this.