### PR TITLE
#188 Add constraints to reject whitespace on meta_vars

### DIFF
--- a/pycds/alembic/versions/5c841d2c01d1_reject_whitespace_on_meta_vars.py
+++ b/pycds/alembic/versions/5c841d2c01d1_reject_whitespace_on_meta_vars.py
@@ -9,6 +9,7 @@ Create Date: 2024-01-10 00:06:47.471826
 from alembic import op
 import sqlalchemy as sa
 from pycds import get_schema_name
+from pycds.orm.tables import no_newline_ck_name, no_newline_ck_check
 
 
 # revision identifiers, used by Alembic.
@@ -34,12 +35,6 @@ replace_value = " "
 
 # This migration applies the same check and update operation to multiple columns. We can reduce some of this repetition
 # by defining some string templates that apply the column
-def constraint_name_template(column):
-    return f"ck_{column}_no_newlines"
-
-
-def constraint_check_template(column):
-    return f"{column} !~ '[\r\n]'"
 
 
 def strip_newlines_update_template(column):
@@ -65,9 +60,9 @@ def upgrade():
     update_table()
     for column in columns_to_apply:
         op.create_check_constraint(
-            constraint_name_template(column),
+            no_newline_ck_name(column),
             table_name,
-            constraint_check_template(column),
+            no_newline_ck_check(column),
             schema=schema_name,
         )
 
@@ -75,7 +70,7 @@ def upgrade():
 def downgrade():
     for column in columns_to_apply:
         op.drop_constraint(
-            constraint_name_template(column),
+            no_newline_ck_name(column),
             table_name,
             schema=schema_name,
             type_="check",

--- a/pycds/alembic/versions/5c841d2c01d1_reject_whitespace_on_meta_vars.py
+++ b/pycds/alembic/versions/5c841d2c01d1_reject_whitespace_on_meta_vars.py
@@ -1,0 +1,83 @@
+"""Updates text columns in meta_var to strip newlines and add constraints
+preventing further whitespace from being added.
+
+Revision ID: 5c841d2c01d1
+Revises: 6cb393f711c3
+Create Date: 2024-01-10 00:06:47.471826
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from pycds import get_schema_name
+
+
+# revision identifiers, used by Alembic.
+revision = "5c841d2c01d1"
+down_revision = "6cb393f711c3"
+branch_labels = None
+depends_on = None
+
+
+schema_name = get_schema_name()
+table_name = "meta_vars"
+columns_to_apply = [
+    "unit",
+    "standard_name",
+    "cell_method",
+    "display_name",
+    "short_name",
+    "long_description",
+]
+# existing newlines will be replaced with a single space.
+replace_value = " "
+
+
+# This migration applies the same check and update operation to multiple columns. We can reduce some of this repetition
+# by defining some string templates that apply the column
+def constraint_name_template(column):
+    return f"ck_{column}_no_newlines"
+
+
+def constraint_check_template(column):
+    return f"{column} !~ '[\r\n]'"
+
+
+def strip_newlines_update_template(column):
+    return f"""
+        UPDATE {schema_name}.meta_vars SET {column} = regexp_replace({column}, '[\r\n]+', '{replace_value}', 'g') 
+        WHERE {column} ~ '[\r\n]+';
+    """
+
+
+def update_table():
+    update_statement = "\n".join(
+        list(map(strip_newlines_update_template, columns_to_apply))
+    )
+    op.execute(update_statement)
+
+
+def regress_table():
+    # The data change here is not reversible due to a loss of specific information
+    pass
+
+
+def upgrade():
+    update_table()
+    for column in columns_to_apply:
+        op.create_check_constraint(
+            constraint_name_template(column),
+            table_name,
+            constraint_check_template(column),
+            schema=schema_name,
+        )
+
+
+def downgrade():
+    for column in columns_to_apply:
+        op.drop_constraint(
+            constraint_name_template(column),
+            table_name,
+            schema=schema_name,
+            type_="check",
+        )
+    regress_table()

--- a/pycds/alembic/versions/5c841d2c01d1_reject_whitespace_on_meta_vars.py
+++ b/pycds/alembic/versions/5c841d2c01d1_reject_whitespace_on_meta_vars.py
@@ -1,5 +1,4 @@
-"""Updates text columns in meta_var to strip newlines and add constraints
-preventing further whitespace from being added.
+"""Add whitespace constraints to meta_vars
 
 Revision ID: 5c841d2c01d1
 Revises: 6cb393f711c3
@@ -14,7 +13,7 @@ from pycds.orm.tables import no_newline_ck_name, no_newline_ck_check
 
 # revision identifiers, used by Alembic.
 revision = "5c841d2c01d1"
-down_revision = "6cb393f711c3"
+down_revision = "efde19ea4f52"
 branch_labels = None
 depends_on = None
 

--- a/pycds/alembic/versions/5c841d2c01d1_reject_whitespace_on_meta_vars.py
+++ b/pycds/alembic/versions/5c841d2c01d1_reject_whitespace_on_meta_vars.py
@@ -39,7 +39,7 @@ replace_value = " "
 
 def strip_newlines_update_template(column):
     return f"""
-        UPDATE {schema_name}.meta_vars SET {column} = regexp_replace({column}, '[\r\n]+', '{replace_value}', 'g') 
+        UPDATE {schema_name}.{table_name} SET {column} = regexp_replace({column}, '[\r\n]+', '{replace_value}', 'g') 
         WHERE {column} ~ '[\r\n]+';
     """
 

--- a/pycds/database.py
+++ b/pycds/database.py
@@ -5,7 +5,7 @@ from pycds.context import get_schema_name
 
 
 def check_migration_version(
-    executor, schema_name=get_schema_name(), version="efde19ea4f52"
+    executor, schema_name=get_schema_name(), version="5c841d2c01d1"
 ):
     """Check that the migration version of the database schema is compatible
     with the current version of this package.

--- a/pycds/orm/tables.py
+++ b/pycds/orm/tables.py
@@ -267,6 +267,14 @@ class TimeBound(Base):
     end = Column(DateTime)
 
 
+def no_newline_ck_name(column):
+    return f"ck_{column}_no_newlines"
+
+
+def no_newline_ck_check(column):
+    return f"{column} !~ '[\r\n]'"
+
+
 class Variable(Base):
     """This class maps to the table which records the details of the
     physical quantities which are recorded by the weather stations.
@@ -276,11 +284,20 @@ class Variable(Base):
     id = Column("vars_id", Integer, primary_key=True)
     name = Column("net_var_name", CIText())
     unit = Column(String)
-    standard_name = Column(String, nullable=False)
+    standard_name = Column(
+        String,
+        nullable=False,
+    )
     cell_method = Column(String, nullable=False)
     precision = Column(Float)
-    description = Column("long_description", String)
-    display_name = Column(String, nullable=False)
+    description = Column(
+        "long_description",
+        String,
+    )
+    display_name = Column(
+        String,
+        nullable=False,
+    )
     short_name = Column(String)
     network_id = Column(Integer, ForeignKey("meta_network.network_id"))
 
@@ -303,6 +320,24 @@ class Variable(Base):
         CheckConstraint(
             "net_var_name ~ '^[a-zA-Z_][a-zA-Z0-9_$]*$'",
             name="ck_net_var_name_valid_identifier",
+        ),
+        CheckConstraint(no_newline_ck_check("unit"), name=no_newline_ck_name("unit")),
+        CheckConstraint(
+            no_newline_ck_check("short_name"), name=no_newline_ck_name("short_name")
+        ),
+        CheckConstraint(
+            no_newline_ck_check("display_name"), name=no_newline_ck_name("display_name")
+        ),
+        CheckConstraint(
+            no_newline_ck_check("cell_method"), name=no_newline_ck_name("cell_method")
+        ),
+        CheckConstraint(
+            no_newline_ck_check("standard_name"),
+            name=no_newline_ck_name("standard_name"),
+        ),
+        CheckConstraint(
+            no_newline_ck_check("long_description"),
+            name=no_newline_ck_name("long_description"),
         ),
     )
 

--- a/tests/alembic_migrations/test_check_migration_version.py
+++ b/tests/alembic_migrations/test_check_migration_version.py
@@ -7,7 +7,7 @@ from pycds.database import check_migration_version
 
 
 def test_get_current_head():
-    assert get_current_head() == "efde19ea4f52"
+    assert get_current_head() == "5c841d2c01d1"
 
 
 @pytest.mark.usefixtures("new_db_left")

--- a/tests/alembic_migrations/versions/v_5c841d2c01d1_reject_whitespace_on_meta_vars/conftest.py
+++ b/tests/alembic_migrations/versions/v_5c841d2c01d1_reject_whitespace_on_meta_vars/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def target_revision():
+    return "5c841d2c01d1"

--- a/tests/alembic_migrations/versions/v_5c841d2c01d1_reject_whitespace_on_meta_vars/test_smoke.py
+++ b/tests/alembic_migrations/versions/v_5c841d2c01d1_reject_whitespace_on_meta_vars/test_smoke.py
@@ -16,7 +16,7 @@ from psycopg2.errors import CheckViolation
 logger = logging.getLogger("tests")
 
 # this is the revision *before* the migration is to be run.
-down_revision = "6cb393f711c3"
+down_revision = "efde19ea4f52"
 target_revision = "5c841d2c01d1"
 
 columns_to_test = [

--- a/tests/alembic_migrations/versions/v_5c841d2c01d1_reject_whitespace_on_meta_vars/test_smoke.py
+++ b/tests/alembic_migrations/versions/v_5c841d2c01d1_reject_whitespace_on_meta_vars/test_smoke.py
@@ -16,41 +16,55 @@ from psycopg2.errors import CheckViolation
 logger = logging.getLogger("tests")
 
 # this is the revision *before* the migration is to be run.
-prior_revision = "bb2a222a1d4a"
-final_revision = "78260d36e42b"
+down_revision = "6cb393f711c3"
+target_revision = "5c841d2c01d1"
+
+columns_to_apply = [
+    "unit",
+    "standard_name",
+    "cell_method",
+    "display_name",
+    "short_name",
+    "long_description",
+]
+
+
+# This higher order function turns a test value into a column prefixed value optionally quoted with single quotes for SQL statements
+def column_value(value, quoted=True):
+    def wrap_sql_string(column_name):
+        prefixed = f"{column_name}_{value}"
+        return f"'{prefixed}'" if quoted else prefixed
+
+    return wrap_sql_string
 
 
 def get_insert_statement(schema_name, insertion_value, vars_id=1):
     return (
-        f"INSERT INTO {schema_name}.meta_vars(vars_id, net_var_name, standard_name, cell_method, display_name)\n"
-        f"VALUES ({vars_id}, '{insertion_value}', 'test', 'test', 'test');\n"
+        f"INSERT INTO {schema_name}.meta_vars(vars_id, {', '.join(columns_to_apply)})\n"
+        f"VALUES ({vars_id}, {',  '.join(list(map(column_value(insertion_value), columns_to_apply)))});\n"
     )
 
 
 @pytest.mark.usefixtures("new_db_left")
 @pytest.mark.parametrize(
-    "prepared_schema_from_migrations_left", (prior_revision,), indirect=True
+    "prepared_schema_from_migrations_left", (down_revision,), indirect=True
 )
 def test_upgrade(
     prepared_schema_from_migrations_left,
     alembic_config_left,
     schema_name,
 ):
-    """test migration from bb2a222a1d4a to 78260d36e42b."""
+    """test migration from fecff1a73d7e to 5c841d2c01d1."""
 
-    # Set up database to version bb2a222a1d4a (previous migration)
+    # Set up database to version fecff1a73d7e (down migration)
     engine, script = prepared_schema_from_migrations_left
 
     # (insertion_id, insertion_value, expected_value)
     test_values = [
-        (1, "bad var name with whitespace", "bad_var_name_with_whitespace"),
-        (2, "bad\nnewline", "bad_newline"),
-        (3, "bad-dash", "bad_dash"),
-        (4, "1badnumber", "_badnumber"),
-        (5, "$badDollar", "_badDollar"),
-        (6, "schön", "schon"),
-        (7, "forêt", "foret"),
-        (8, "tréma", "trema"),
+        (1, "bad\rfeed", "bad feed"),
+        (2, "bad\nnewline", "bad newline"),
+        (3, "bad\r\nreturn", "bad return"),
+        (4, "bad\rmix\nof\r\nall", "bad mix of all"),
     ]
 
     def inserter(x):
@@ -62,49 +76,63 @@ def test_upgrade(
     command.upgrade(alembic_config_left, "+1")
 
     result = engine.execute(
-        f"SELECT vars_id, net_var_name FROM {schema_name}.meta_vars ORDER BY vars_id"
+        f"SELECT vars_id, {', '.join(columns_to_apply)} FROM {schema_name}.meta_vars ORDER BY vars_id"
     )
 
     for index, row in enumerate(result):
         test_sample = test_values[index]
-        assert row == (test_sample[0], test_sample[2])
+        assert row == (
+            test_sample[0],
+            # Spread our tested columns test values to create a tuple, each is made unique by prefixing the
+            # column name so we shouldn't get any false positive tests due to column mis-ordering
+            *list(map(column_value(test_sample[2], quoted=False), columns_to_apply)),
+        )
 
 
 @pytest.mark.usefixtures("new_db_left")
 @pytest.mark.parametrize(
-    "prepared_schema_from_migrations_left", (final_revision,), indirect=True
+    "prepared_schema_from_migrations_left", ((target_revision),), indirect=True
 )
 def test_downgrade(
     prepared_schema_from_migrations_left,
     alembic_config_left,
     schema_name,
 ):
-    """test migration from 78260d36e42b to bb2a222a1d4a."""
+    """test migration from 5c841d2c01d1 to fecff1a73d7e."""
 
-    # Set up database to version bb2a222a1d4a (previous migration)
+    # Set up database to version 5c841d2c01d1 (target migration)
     engine, script = prepared_schema_from_migrations_left
 
-    statement = get_insert_statement(schema_name, "good_var_name_with_underscores")
+    statement = get_insert_statement(
+        schema_name, "good value that does not contain newlines"
+    )
     engine.execute(statement)
 
     command.downgrade(alembic_config_left, "-1")
 
     result = engine.execute(
-        f"SELECT vars_id, net_var_name FROM {schema_name}.meta_vars"
+        f"SELECT vars_id, {', '.join(columns_to_apply)} FROM {schema_name}.meta_vars"
     )
 
     row = next(result)
 
-    # After migration is run, bad strings should have whitespace replaced with underscores
-    assert row == (1, "good_var_name_with_underscores")
+    # After migration is reversed, data should be unchanged
+    assert row == (
+        1,
+        *list(
+            map(
+                column_value("good value that does not contain newlines", quoted=False),
+                columns_to_apply,
+            )
+        ),
+    )
 
 
 @pytest.mark.usefixtures("new_db_left")
 @pytest.mark.parametrize(
-    "prepared_schema_from_migrations_left", (final_revision,), indirect=True
+    "prepared_schema_from_migrations_left", (target_revision,), indirect=True
 )
-# Correct values should conform to https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
-# Notably numbers and $ are allowed, but not as the first character
+# good test values should contain anything but newline characters, this can be a pretty broad sample
 @pytest.mark.parametrize(
     "test_value",
     ["allow_underscores", "allowfullwords", "allowCapitals", "allowNumbers123"],
@@ -112,44 +140,37 @@ def test_downgrade(
 def test_check_good_constraint_values(
     prepared_schema_from_migrations_left, schema_name, test_value
 ):
-    # Set up database to version 78260d36e42b (after migration)
+    # Set up database to version 5c841d2c01d1 (target migration)
     engine, script = prepared_schema_from_migrations_left
 
     statement = get_insert_statement(schema_name, test_value)
     engine.execute(statement)
 
     result = engine.execute(
-        f"SELECT vars_id, net_var_name FROM {schema_name}.meta_vars"
+        f"SELECT vars_id, {', '.join(columns_to_apply)} FROM {schema_name}.meta_vars"
     )
 
     row = next(result)
 
-    assert row == (1, test_value)
+    assert row == (
+        1,
+        *list(map(column_value(test_value, quoted=False), columns_to_apply)),
+    )
 
 
 @pytest.mark.usefixtures("new_db_left")
 @pytest.mark.parametrize(
-    "prepared_schema_from_migrations_left", (final_revision,), indirect=True
+    "prepared_schema_from_migrations_left", (target_revision,), indirect=True
 )
-# Correct values should conform to https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
-# Notably numbers and $ are allowed, but not as the first character
+# bad test values will cause the constraint check to error with one or more newline type characters.
 @pytest.mark.parametrize(
     "test_value",
-    [
-        "bad space",
-        "bad\nnewline",
-        "bad-dash",
-        "1badnumber",
-        "$badDollar",
-        "schön",
-        "forêt",
-        "tréma",
-    ],
+    ["bad\rreturn", "bad\nfeed", "bad\r\nnewline", "bad\rmix\nof\r\nall"],
 )
 def test_check_bad_constraint_values(
     prepared_schema_from_migrations_left, schema_name, test_value
 ):
-    # Set up database to version 78260d36e42b (after migration)
+    # Set up database to version 5c841d2c01d1 (target migration)
     engine, script = prepared_schema_from_migrations_left
     # This test passes bad data and expects an integrity error back from SQLAlchemy when executed
     with pytest.raises(IntegrityError) as excinfo:

--- a/tests/alembic_migrations/versions/v_78260d36e42b_add_net_var_name_valid_identifier_check/test_smoke.py
+++ b/tests/alembic_migrations/versions/v_78260d36e42b_add_net_var_name_valid_identifier_check/test_smoke.py
@@ -65,8 +65,7 @@ def test_upgrade(
         f"SELECT vars_id, net_var_name FROM {schema_name}.meta_vars ORDER BY vars_id"
     )
 
-    for index, row in enumerate(result):
-        test_sample = test_values[index]
+    for row, test_sample in zip(result, test_values):
         assert row == (test_sample[0], test_sample[2])
 
 


### PR DESCRIPTION
Fixes #188 

- Add migration with data update to fix existing values
- Add unit tests to test migration up and down
- Add unit tests to test check constraint as applied to all columns
- Fix net var name migration to correctly insert bad data prior to migration test

**For Reviewers**
- Check I'm applying to the correct columns