### PR TITLE
Grant appropriate permissions on newly created objects in migrations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ Changes:
 
 ## 4.3.0
 
-*Release Date: 2023-Apr-05*
+*Release Date: 2023-Nov-11*
 
 Key change in this release is to install script `manage-views`.
 

--- a/pycds/alembic/extensions/operation_plugins/__init__.py
+++ b/pycds/alembic/extensions/operation_plugins/__init__.py
@@ -17,6 +17,7 @@ https://alembic.sqlalchemy.org/en/latest/api/operations.html#operation-plugins
 # Imports are required to register the new operations.
 from .simple_operations import (
     constraint,
+    grant,
     index,
     role,
     table,

--- a/pycds/alembic/extensions/operation_plugins/simple_operations/grant.py
+++ b/pycds/alembic/extensions/operation_plugins/simple_operations/grant.py
@@ -12,10 +12,9 @@ from pycds.sqlalchemy.ddl_extensions import GrantTablePrivileges
 
 @Operations.register_operation("grant_table_privileges")
 class GrantTablePrivilegesOp(MigrateOperation):
-    """GRANT on table-like object operation"""
+    """Alembic operation for GRANT directive on a table-like object"""
 
     def __init__(self, privileges, table_name, role_specification, schema=None):
-        # super().__init__()
         self.privileges = privileges
         self.table_name = table_name
         self.role_specification = role_specification

--- a/pycds/alembic/extensions/operation_plugins/simple_operations/grant.py
+++ b/pycds/alembic/extensions/operation_plugins/simple_operations/grant.py
@@ -1,0 +1,39 @@
+"""
+Plugins that add GRANT operations available to migrations in Alembic.
+
+A plugin has 2 parts:
+- an operation that is registered with Alembic; a subclass of MigrateOperation
+- an implementation of the operation; a method that executes a SQL command
+"""
+
+from alembic.operations import Operations, MigrateOperation
+from pycds.sqlalchemy.ddl_extensions import GrantTablePrivileges
+
+
+@Operations.register_operation("grant_table_privileges")
+class GrantTablePrivilegesOp(MigrateOperation):
+    """GRANT on table-like object operation"""
+
+    def __init__(self, privileges, table_name, role_specification, schema=None):
+        # super().__init__()
+        self.privileges = privileges
+        self.table_name = table_name
+        self.role_specification = role_specification
+        self.schema = schema
+
+    @classmethod
+    def grant_table_privileges(cls, operations, *args, **kw):
+        """Issue a GRANT on table-like object command."""
+        return operations.invoke(cls(*args, **kw))
+
+
+@Operations.implementation_for(GrantTablePrivilegesOp)
+def implement_grant_table_privileges(operations, operation):
+    operations.execute(
+        GrantTablePrivileges(
+            operation.privileges,
+            operation.table_name,
+            operation.role_specification,
+            schema=operation.schema,
+        )
+    )

--- a/pycds/alembic/util.py
+++ b/pycds/alembic/util.py
@@ -1,8 +1,40 @@
 from typing import List, Union, Tuple
 
 from sqlalchemy.sql.ddl import DDLElement
-
 from alembic import op
+
+
+def create_view_or_matview(obj, schema=None, grant_privs=True, create_indexes=True):
+    """Drop a matview, and optionally create the indexes associated with it. """
+    # Create the matview
+    op.create_replaceable_object(obj, schema=schema)
+    if grant_privs:
+        grant_standard_table_privileges(obj, schema=schema)
+    if create_indexes:
+        # Create any indices on the matview
+        for index in obj.__table__.indexes:
+            op.create_index(
+                index_name=index.name,
+                table_name=index.table.name,
+                columns=[col.name for col in index.columns],
+                unique=index.unique,
+                schema=schema,
+            )
+
+
+def drop_view_or_matview(obj, schema=None, drop_indexes=True):
+    """Drop a matview, and optionally drop the indexes associated with it. """
+    if drop_indexes:
+        # Drop any indexes on the matview
+        for index in obj.__table__.indexes:
+            op.drop_index(
+                index_name=index.name,
+                table_name=index.table.name,
+                schema=schema,
+            )
+    # Drop the matview
+    op.drop_replaceable_object(obj, schema=schema)
+
 
 
 def grant_standard_table_privileges(
@@ -14,7 +46,7 @@ def grant_standard_table_privileges(
     ),
     schema: str = None,
 ) -> None:
-    """Grant standard privileges on a table-like object (table, view, matview).
+    """Grant standard privileges on a table-like object (table, view, table_object).
 
     :param obj: Table-like ORM object or string identifying the object permissions
         are to be granted on.

--- a/pycds/alembic/util.py
+++ b/pycds/alembic/util.py
@@ -1,0 +1,28 @@
+from typing import List, Union, Tuple
+
+from sqlalchemy.sql.ddl import DDLElement
+
+from alembic import op
+
+
+def grant_standard_table_privileges(
+    obj: Union[DDLElement, str],
+    role_privileges: List[Tuple[str, Tuple[str]]] = (
+        ("inspector", ("SELECT",)),
+        ("viewer", ("SELECT",)),
+        ("steward", ("ALL",)),
+    ),
+    schema: str = None,
+) -> None:
+    """Grant standard privileges on a table-like object (table, view, matview).
+
+    :param obj: Table-like ORM object or string identifying the object permissions
+        are to be granted on.
+    :param role_privileges: Iterable of pairs `(role, permissions)`, where `role`
+        is a string containing the role name, and `permissions` is an iterable of
+        permissions (strings) to be granted on the object to `role`.
+    :param schema: Name of schema in which object exists.
+    """
+    obj_name = obj if isinstance(obj, str) else obj.__tablename__
+    for role, privileges in role_privileges:
+        op.grant_table_privileges(privileges, obj_name, role, schema=schema)

--- a/pycds/alembic/util.py
+++ b/pycds/alembic/util.py
@@ -5,7 +5,9 @@ from alembic import op
 
 
 def create_view(obj, schema=None, grant_privs=True):
-    create_view_or_matview(obj, schema=schema, grant_privs=grant_privs, create_indexes=False)
+    create_view_or_matview(
+        obj, schema=schema, grant_privs=grant_privs, create_indexes=False
+    )
 
 
 def create_matview(obj, **kwargs):
@@ -13,7 +15,7 @@ def create_matview(obj, **kwargs):
 
 
 def create_view_or_matview(obj, schema=None, grant_privs=True, create_indexes=True):
-    """Drop a matview, and optionally create the indexes associated with it. """
+    """Drop a matview, and optionally create the indexes associated with it."""
     # Create the matview
     op.create_replaceable_object(obj, schema=schema)
     if grant_privs:
@@ -39,7 +41,7 @@ def drop_matview(obj, **kwargs):
 
 
 def drop_view_or_matview(obj, schema=None, drop_indexes=True):
-    """Drop a matview, and optionally drop the indexes associated with it. """
+    """Drop a matview, and optionally drop the indexes associated with it."""
     if drop_indexes:
         # Drop any indexes on the matview
         for index in obj.__table__.indexes:
@@ -50,7 +52,6 @@ def drop_view_or_matview(obj, schema=None, drop_indexes=True):
             )
     # Drop the matview
     op.drop_replaceable_object(obj, schema=schema)
-
 
 
 def grant_standard_table_privileges(

--- a/pycds/alembic/util.py
+++ b/pycds/alembic/util.py
@@ -27,6 +27,7 @@ def drop_view_or_matview(obj, schema=None, drop_indexes=True):
     if drop_indexes:
         # Drop any indexes on the matview
         for index in obj.__table__.indexes:
+            print(f"### dropping {index.name} on {schema}.{index.table.name}")
             op.drop_index(
                 index_name=index.name,
                 table_name=index.table.name,

--- a/pycds/alembic/util.py
+++ b/pycds/alembic/util.py
@@ -16,13 +16,11 @@ def create_matview(obj, **kwargs):
 
 
 def create_view_or_matview(obj, schema=None, grant_privs=True, create_indexes=True):
-    """Drop a matview, and optionally create the indexes associated with it."""
-    # Create the matview
+    """Create a view or matview, and optionally create the indexes associated with it."""
     op.create_replaceable_object(obj, schema=schema)
     if grant_privs:
         grant_standard_table_privileges(obj, schema=schema)
     if create_indexes:
-        # Create any indices on the matview
         for index in obj.__table__.indexes:
             op.create_index(
                 index_name=index.name,
@@ -42,16 +40,14 @@ def drop_matview(obj, **kwargs):
 
 
 def drop_view_or_matview(obj, schema=None, drop_indexes=True):
-    """Drop a matview, and optionally drop the indexes associated with it."""
+    """Drop a view or matview, and optionally drop the indexes associated with it."""
     if drop_indexes:
-        # Drop any indexes on the matview
         for index in obj.__table__.indexes:
             op.drop_index(
                 index_name=index.name,
                 table_name=index.table.name,
                 schema=schema,
             )
-    # Drop the matview
     op.drop_replaceable_object(obj, schema=schema)
 
 
@@ -60,7 +56,7 @@ def grant_standard_table_privileges(
     role_privileges: List[Tuple[str, Tuple[str]]] = get_standard_table_privileges(),
     schema: str = None,
 ) -> None:
-    """Grant standard privileges on a table-like object (table, view, table_object).
+    """Grant standard privileges on a table-like object (table, view, matview).
 
     :param obj: Table-like ORM object or string identifying the object permissions
         are to be granted on.

--- a/pycds/alembic/util.py
+++ b/pycds/alembic/util.py
@@ -4,6 +4,14 @@ from sqlalchemy.sql.ddl import DDLElement
 from alembic import op
 
 
+def create_view(obj, schema=None, grant_privs=True):
+    create_view_or_matview(obj, schema=schema, grant_privs=grant_privs, create_indexes=False)
+
+
+def create_matview(obj, **kwargs):
+    create_view_or_matview(obj, **kwargs)
+
+
 def create_view_or_matview(obj, schema=None, grant_privs=True, create_indexes=True):
     """Drop a matview, and optionally create the indexes associated with it. """
     # Create the matview
@@ -22,12 +30,19 @@ def create_view_or_matview(obj, schema=None, grant_privs=True, create_indexes=Tr
             )
 
 
+def drop_view(obj, schema=None):
+    drop_view_or_matview(obj, schema=schema, drop_indexes=False)
+
+
+def drop_matview(obj, **kwargs):
+    drop_view_or_matview(obj, **kwargs)
+
+
 def drop_view_or_matview(obj, schema=None, drop_indexes=True):
     """Drop a matview, and optionally drop the indexes associated with it. """
     if drop_indexes:
         # Drop any indexes on the matview
         for index in obj.__table__.indexes:
-            print(f"### dropping {index.name} on {schema}.{index.table.name}")
             op.drop_index(
                 index_name=index.name,
                 table_name=index.table.name,

--- a/pycds/alembic/util.py
+++ b/pycds/alembic/util.py
@@ -2,6 +2,7 @@ from typing import List, Union, Tuple
 
 from sqlalchemy.sql.ddl import DDLElement
 from alembic import op
+from pycds.context import get_standard_table_privileges
 
 
 def create_view(obj, schema=None, grant_privs=True):
@@ -56,11 +57,7 @@ def drop_view_or_matview(obj, schema=None, drop_indexes=True):
 
 def grant_standard_table_privileges(
     obj: Union[DDLElement, str],
-    role_privileges: List[Tuple[str, Tuple[str]]] = (
-        ("inspector", ("SELECT",)),
-        ("viewer", ("SELECT",)),
-        ("steward", ("ALL",)),
-    ),
+    role_privileges: List[Tuple[str, Tuple[str]]] = get_standard_table_privileges(),
     schema: str = None,
 ) -> None:
     """Grant standard privileges on a table-like object (table, view, table_object).

--- a/pycds/alembic/versions/22819129a609_convert_collapsed_vars_mv_to_native_.py
+++ b/pycds/alembic/versions/22819129a609_convert_collapsed_vars_mv_to_native_.py
@@ -18,8 +18,10 @@ from pycds.orm.views.version_22819129a609 import (
 from pycds.orm.views.version_84b7fc2596d5 import CrmpNetworkGeoserver
 from pycds.alembic.util import (
     grant_standard_table_privileges,
-    create_view_or_matview,
-    drop_view_or_matview,
+    create_view,
+    drop_view,
+    create_matview,
+    drop_matview,
 )
 
 # revision identifiers, used by Alembic.
@@ -34,11 +36,11 @@ schema_name = get_schema_name()
 
 
 def drop_dependent_objects():
-    drop_view_or_matview(CrmpNetworkGeoserver, schema=schema_name, drop_indexes=False)
+    drop_view(CrmpNetworkGeoserver, schema=schema_name)
 
 
 def create_dependent_objects():
-    create_view_or_matview(CrmpNetworkGeoserver, schema=schema_name, create_indexes=False)
+    create_view(CrmpNetworkGeoserver, schema=schema_name)
 
 
 def upgrade():
@@ -47,10 +49,10 @@ def upgrade():
 
     # Drop fake matview table and its associated view
     op.drop_table_if_exists(CollapsedVariablesMatview.__tablename__, schema=schema_name)
-    op.drop_replaceable_object(CollapsedVariablesView, schema=schema_name)
+    drop_view(CollapsedVariablesView, schema=schema_name)
 
     # Replace them with the native matview
-    create_view_or_matview(CollapsedVariablesMatview, schema=schema_name)
+    create_matview(CollapsedVariablesMatview, schema=schema_name)
 
     # Restore dependent objects
     create_dependent_objects()
@@ -61,7 +63,7 @@ def downgrade():
     drop_dependent_objects()
 
     # Drop real native matview
-    drop_view_or_matview(CollapsedVariablesMatview, schema=schema_name)
+    drop_matview(CollapsedVariablesMatview, schema=schema_name)
 
     # Replace with fake matview table
     op.create_table(
@@ -76,7 +78,7 @@ def downgrade():
         schema=schema_name,
     )
     grant_standard_table_privileges("collapsed_vars_mv", schema=schema_name)
-    create_view_or_matview(CollapsedVariablesView, schema=schema_name)
+    create_view(CollapsedVariablesView, schema=schema_name)
 
     # Restore dependent objects
     create_dependent_objects()

--- a/pycds/alembic/versions/22819129a609_convert_collapsed_vars_mv_to_native_.py
+++ b/pycds/alembic/versions/22819129a609_convert_collapsed_vars_mv_to_native_.py
@@ -34,11 +34,11 @@ schema_name = get_schema_name()
 
 
 def drop_dependent_objects():
-    drop_view_or_matview(CrmpNetworkGeoserver, schema=schema_name)
+    drop_view_or_matview(CrmpNetworkGeoserver, schema=schema_name, drop_indexes=False)
 
 
 def create_dependent_objects():
-    create_view_or_matview(CrmpNetworkGeoserver, schema=schema_name)
+    create_view_or_matview(CrmpNetworkGeoserver, schema=schema_name, create_indexes=False)
 
 
 def upgrade():

--- a/pycds/alembic/versions/7a3b247c577b_add_varsperhistory_native_matview.py
+++ b/pycds/alembic/versions/7a3b247c577b_add_varsperhistory_native_matview.py
@@ -8,6 +8,10 @@ Create Date: 2021-01-18 17:06:14.064487
 import logging
 from alembic import op
 import sqlalchemy as sa
+from pycds.alembic.util import (
+    create_view_or_matview, drop_view_or_matview,
+    grant_standard_table_privileges,
+)
 from pycds import get_schema_name
 from pycds.orm.native_matviews.version_7a3b247c577b import VarsPerHistory
 from pycds.database import db_supports_matviews
@@ -30,16 +34,7 @@ def upgrade():
     if db_supports_matviews(engine):
         logger.debug("This database supports native materialized views")
         op.drop_table_if_exists("vars_per_history_mv", schema=schema_name)
-        op.create_replaceable_object(VarsPerHistory)
-        for index in VarsPerHistory.__table__.indexes:
-            logger.debug(f"Creating index '{index.name}'")
-            op.create_index(
-                index_name=index.name,
-                table_name=index.table.name,
-                columns=[col.name for col in index.columns],
-                unique=index.unique,
-                schema=schema_name,
-            )
+        create_view_or_matview(VarsPerHistory, schema=schema_name)
     else:
         logger.info(
             "This database does not support native materialized views: "
@@ -51,14 +46,7 @@ def downgrade():
     engine = op.get_bind().engine
     if db_supports_matviews(engine):
         logger.debug("This database supports matviews")
-        for index in VarsPerHistory.__table__.indexes:
-            logger.debug(f"Dropping index '{index.name}'")
-            op.drop_index(
-                index_name=index.name,
-                table_name=index.table.name,
-                schema=schema_name,
-            )
-        op.drop_replaceable_object(VarsPerHistory)
+        drop_view_or_matview(VarsPerHistory, schema=schema_name)
         # Note: This will create the table in the database even if it didn't
         # exist before. At the time of writing, this is the desired behaviour.
         op.create_table(
@@ -72,6 +60,7 @@ def downgrade():
             sa.PrimaryKeyConstraint("history_id", "vars_id"),
             schema=schema_name,
         )
+        grant_standard_table_privileges("vars_per_history_mv", schema=schema_name)
     else:
         logger.info(
             "This database does not support native materialized views: "

--- a/pycds/alembic/versions/7a3b247c577b_add_varsperhistory_native_matview.py
+++ b/pycds/alembic/versions/7a3b247c577b_add_varsperhistory_native_matview.py
@@ -9,8 +9,9 @@ import logging
 from alembic import op
 import sqlalchemy as sa
 from pycds.alembic.util import (
-    create_view_or_matview, drop_view_or_matview,
     grant_standard_table_privileges,
+    create_matview,
+    drop_matview,
 )
 from pycds import get_schema_name
 from pycds.orm.native_matviews.version_7a3b247c577b import VarsPerHistory
@@ -34,7 +35,7 @@ def upgrade():
     if db_supports_matviews(engine):
         logger.debug("This database supports native materialized views")
         op.drop_table_if_exists("vars_per_history_mv", schema=schema_name)
-        create_view_or_matview(VarsPerHistory, schema=schema_name)
+        create_matview(VarsPerHistory, schema=schema_name)
     else:
         logger.info(
             "This database does not support native materialized views: "
@@ -46,7 +47,7 @@ def downgrade():
     engine = op.get_bind().engine
     if db_supports_matviews(engine):
         logger.debug("This database supports matviews")
-        drop_view_or_matview(VarsPerHistory, schema=schema_name)
+        drop_matview(VarsPerHistory, schema=schema_name)
         # Note: This will create the table in the database even if it didn't
         # exist before. At the time of writing, this is the desired behaviour.
         op.create_table(

--- a/pycds/alembic/versions/96729d6db8b3_convert_climo_obs_count_mv_to_native_.py
+++ b/pycds/alembic/versions/96729d6db8b3_convert_climo_obs_count_mv_to_native_.py
@@ -9,8 +9,10 @@ import logging
 from alembic import op
 import sqlalchemy as sa
 from pycds.alembic.util import (
-    drop_view_or_matview, create_view_or_matview,
     grant_standard_table_privileges,
+    create_matview,
+    create_view,
+    drop_matview,
 )
 from pycds import get_schema_name
 from pycds.orm.native_matviews.version_96729d6db8b3 import (
@@ -33,11 +35,11 @@ schema_name = get_schema_name()
 def upgrade():
     op.drop_replaceable_object(ClimoObsCountView)
     op.drop_table_if_exists(ClimoObsCountMatview.__tablename__, schema=schema_name)
-    create_view_or_matview(ClimoObsCountMatview, schema=schema_name)
+    create_matview(ClimoObsCountMatview, schema=schema_name)
 
 
 def downgrade():
-    drop_view_or_matview(ClimoObsCountMatview, schema=schema_name)
+    drop_matview(ClimoObsCountMatview, schema=schema_name)
     op.create_table(
         "climo_obs_count_mv",
         sa.Column("count", sa.BigInteger(), nullable=True),
@@ -49,4 +51,4 @@ def downgrade():
         schema=schema_name,
     )
     grant_standard_table_privileges("climo_obs_count_mv", schema=schema_name)
-    create_view_or_matview(ClimoObsCountView, schema=schema_name)
+    create_view(ClimoObsCountView, schema=schema_name)

--- a/pycds/alembic/versions/bb2a222a1d4a_convert_obs_count_per_month_history_mv_.py
+++ b/pycds/alembic/versions/bb2a222a1d4a_convert_obs_count_per_month_history_mv_.py
@@ -9,8 +9,10 @@ import logging
 from alembic import op
 import sqlalchemy as sa
 from pycds.alembic.util import (
-    drop_view_or_matview, create_view_or_matview,
     grant_standard_table_privileges,
+    create_view,
+    create_matview,
+    drop_matview,
 )
 from pycds import get_schema_name
 from pycds.orm.native_matviews.version_bb2a222a1d4a import (
@@ -40,12 +42,12 @@ def upgrade():
     op.drop_replaceable_object(ObsCountPerMonthHistoryView)
 
     # Replace them with the native matview
-    create_view_or_matview(ObsCountPerMonthHistoryMatview, schema=schema_name)
+    create_matview(ObsCountPerMonthHistoryMatview, schema=schema_name)
 
 
 def downgrade():
     # Drop real native matview
-    drop_view_or_matview(ObsCountPerMonthHistoryMatview, schema=schema_name)
+    drop_matview(ObsCountPerMonthHistoryMatview, schema=schema_name)
 
     # Replace with fake matview table and associated view
     op.create_table(
@@ -59,5 +61,7 @@ def downgrade():
         sa.PrimaryKeyConstraint("date_trunc", "history_id"),
         schema=schema_name,
     )
-    grant_standard_table_privileges("obs_count_per_month_history_mv", schema=schema_name)
-    create_view_or_matview(ObsCountPerMonthHistoryView, schema=schema_name)
+    grant_standard_table_privileges(
+        "obs_count_per_month_history_mv", schema=schema_name
+    )
+    create_view(ObsCountPerMonthHistoryView, schema=schema_name)

--- a/pycds/alembic/versions/bf366199f463_convert_station_obs_stats_mv_to_native_.py
+++ b/pycds/alembic/versions/bf366199f463_convert_station_obs_stats_mv_to_native_.py
@@ -8,6 +8,7 @@ Create Date: 2023-08-18 15:55:38.242505
 import logging
 from alembic import op
 import sqlalchemy as sa
+from pycds.alembic.util import create_view_or_matview, drop_view_or_matview
 from pycds import get_schema_name
 from pycds.orm.native_matviews.version_bf366199f463 import (
     StationObservationStats as StationObservationStatsMatview,
@@ -33,11 +34,11 @@ schema_name = get_schema_name()
 
 
 def drop_dependent_objects():
-    op.drop_replaceable_object(CrmpNetworkGeoserver)
+    drop_view_or_matview(CrmpNetworkGeoserver)
 
 
 def create_dependent_objects():
-    op.create_replaceable_object(CrmpNetworkGeoserver)
+    create_view_or_matview(CrmpNetworkGeoserver)
 
 
 def upgrade():
@@ -51,15 +52,7 @@ def upgrade():
     op.drop_table_if_exists(
         StationObservationStatsMatview.__tablename__, schema=schema_name
     )
-    op.create_replaceable_object(StationObservationStatsMatview, schema=schema_name)
-    for index in StationObservationStatsMatview.__table__.indexes:
-        op.create_index(
-            index_name=index.name,
-            table_name=index.table.name,
-            columns=[col.name for col in index.columns],
-            unique=index.unique,
-            schema=schema_name,
-        )
+    create_view_or_matview(StationObservationStatsMatview, schema=schema_name)
 
     # Restore dependent objects
     create_dependent_objects()
@@ -71,13 +64,7 @@ def downgrade():
     drop_dependent_objects()
 
     # Drop real native matview and replace with fake matview table
-    for index in StationObservationStatsMatview.__table__.indexes:
-        op.drop_index(
-            index_name=index.name,
-            table_name=index.table.name,
-            schema=schema_name,
-        )
-    op.drop_replaceable_object(StationObservationStatsMatview)
+    drop_view_or_matview(StationObservationStatsMatview, schema=schema_name)
     op.create_table(
         "station_obs_stats_mv",
         sa.Column("station_id", sa.Integer(), nullable=False),
@@ -93,7 +80,7 @@ def downgrade():
         ),
         schema=schema_name,
     )
-    op.create_replaceable_object(StationObservationStatsView)
+    create_view_or_matview(StationObservationStatsView, schema=schema_name)
 
     # Restore dependent objects
     create_dependent_objects()

--- a/pycds/alembic/versions/bf366199f463_convert_station_obs_stats_mv_to_native_.py
+++ b/pycds/alembic/versions/bf366199f463_convert_station_obs_stats_mv_to_native_.py
@@ -8,7 +8,7 @@ Create Date: 2023-08-18 15:55:38.242505
 import logging
 from alembic import op
 import sqlalchemy as sa
-from pycds.alembic.util import create_view_or_matview, drop_view_or_matview
+from pycds.alembic.util import create_view, create_matview, drop_matview, drop_view
 from pycds import get_schema_name
 from pycds.orm.native_matviews.version_bf366199f463 import (
     StationObservationStats as StationObservationStatsMatview,
@@ -34,11 +34,11 @@ schema_name = get_schema_name()
 
 
 def drop_dependent_objects():
-    drop_view_or_matview(CrmpNetworkGeoserver, schema=schema_name, drop_indexes=False)
+    drop_view(CrmpNetworkGeoserver, schema=schema_name)
 
 
 def create_dependent_objects():
-    create_view_or_matview(CrmpNetworkGeoserver, schema=schema_name, create_indexes=False)
+    create_view(CrmpNetworkGeoserver, schema=schema_name)
 
 
 def upgrade():
@@ -48,11 +48,11 @@ def upgrade():
 
     # Drop fake matview table and its associated view, and replace them with the
     # native matview
-    op.drop_replaceable_object(StationObservationStatsView)
+    drop_view(StationObservationStatsView, schema=schema_name)
     op.drop_table_if_exists(
         StationObservationStatsMatview.__tablename__, schema=schema_name
     )
-    create_view_or_matview(StationObservationStatsMatview, schema=schema_name)
+    create_matview(StationObservationStatsMatview, schema=schema_name)
 
     # Restore dependent objects
     create_dependent_objects()
@@ -64,7 +64,7 @@ def downgrade():
     drop_dependent_objects()
 
     # Drop real native matview and replace with fake matview table
-    drop_view_or_matview(StationObservationStatsMatview, schema=schema_name)
+    drop_matview(StationObservationStatsMatview, schema=schema_name)
     op.create_table(
         "station_obs_stats_mv",
         sa.Column("station_id", sa.Integer(), nullable=False),
@@ -80,7 +80,7 @@ def downgrade():
         ),
         schema=schema_name,
     )
-    create_view_or_matview(StationObservationStatsView, schema=schema_name)
+    create_view(StationObservationStatsView, schema=schema_name)
 
     # Restore dependent objects
     create_dependent_objects()

--- a/pycds/alembic/versions/bf366199f463_convert_station_obs_stats_mv_to_native_.py
+++ b/pycds/alembic/versions/bf366199f463_convert_station_obs_stats_mv_to_native_.py
@@ -34,11 +34,11 @@ schema_name = get_schema_name()
 
 
 def drop_dependent_objects():
-    drop_view_or_matview(CrmpNetworkGeoserver)
+    drop_view_or_matview(CrmpNetworkGeoserver, schema=schema_name, drop_indexes=False)
 
 
 def create_dependent_objects():
-    create_view_or_matview(CrmpNetworkGeoserver)
+    create_view_or_matview(CrmpNetworkGeoserver, schema=schema_name, create_indexes=False)
 
 
 def upgrade():

--- a/pycds/alembic/versions/fecff1a73d7e_update_matview_collapsed_vars_mv.py
+++ b/pycds/alembic/versions/fecff1a73d7e_update_matview_collapsed_vars_mv.py
@@ -7,11 +7,7 @@ Create Date: 2023-12-19 14:36:43.362862
 """
 import logging
 from alembic import op
-from pycds.alembic.util import (
-    grant_standard_table_privileges,
-    drop_view_or_matview,
-    create_view_or_matview,
-)
+from pycds.alembic.util import create_view, create_matview, drop_matview, drop_view
 from pycds.orm.native_matviews.version_22819129a609 import (
     CollapsedVariables as OldCollapsedVariables,
 )
@@ -35,22 +31,22 @@ schema_name = get_schema_name()
 
 
 def drop_dependent_objects():
-    drop_view_or_matview(CrmpNetworkGeoserver, schema=schema_name, drop_indexes=False)
+    drop_view(CrmpNetworkGeoserver, schema=schema_name)
 
 
 def create_dependent_objects():
-    create_view_or_matview(CrmpNetworkGeoserver, schema=schema_name, create_indexes=False)
+    create_view(CrmpNetworkGeoserver, schema=schema_name)
 
 
 def upgrade():
     drop_dependent_objects()
-    drop_view_or_matview(OldCollapsedVariables)
-    create_view_or_matview(NewCollapsedVariables)
+    drop_matview(OldCollapsedVariables, schema=schema_name)
+    create_matview(NewCollapsedVariables, schema=schema_name)
     create_dependent_objects()
 
 
 def downgrade():
     drop_dependent_objects()
-    drop_view_or_matview(NewCollapsedVariables)
-    create_view_or_matview(OldCollapsedVariables)
+    drop_matview(NewCollapsedVariables, schema=schema_name)
+    create_matview(OldCollapsedVariables, schema=schema_name)
     create_dependent_objects()

--- a/pycds/alembic/versions/fecff1a73d7e_update_matview_collapsed_vars_mv.py
+++ b/pycds/alembic/versions/fecff1a73d7e_update_matview_collapsed_vars_mv.py
@@ -35,11 +35,11 @@ schema_name = get_schema_name()
 
 
 def drop_dependent_objects():
-    drop_view_or_matview(CrmpNetworkGeoserver, schema=schema_name)
+    drop_view_or_matview(CrmpNetworkGeoserver, schema=schema_name, drop_indexes=False)
 
 
 def create_dependent_objects():
-    create_view_or_matview(CrmpNetworkGeoserver, schema=schema_name)
+    create_view_or_matview(CrmpNetworkGeoserver, schema=schema_name, create_indexes=False)
 
 
 def upgrade():

--- a/pycds/alembic/versions/fecff1a73d7e_update_matview_collapsed_vars_mv.py
+++ b/pycds/alembic/versions/fecff1a73d7e_update_matview_collapsed_vars_mv.py
@@ -7,6 +7,11 @@ Create Date: 2023-12-19 14:36:43.362862
 """
 import logging
 from alembic import op
+from pycds.alembic.util import (
+    grant_standard_table_privileges,
+    drop_view_or_matview,
+    create_view_or_matview,
+)
 from pycds.orm.native_matviews.version_22819129a609 import (
     CollapsedVariables as OldCollapsedVariables,
 )
@@ -30,48 +35,22 @@ schema_name = get_schema_name()
 
 
 def drop_dependent_objects():
-    op.drop_replaceable_object(CrmpNetworkGeoserver, schema=schema_name)
+    drop_view_or_matview(CrmpNetworkGeoserver, schema=schema_name)
 
 
 def create_dependent_objects():
-    op.create_replaceable_object(CrmpNetworkGeoserver, schema=schema_name)
-
-
-def drop_matview(matview, schema=schema_name):
-    # Drop any indices on the matview
-    for index in matview.__table__.indexes:
-        op.drop_index(
-            index_name=index.name,
-            table_name=index.table.name,
-            schema=schema,
-        )
-    # Drop the matview
-    op.drop_replaceable_object(matview, schema=schema)
-
-
-def create_matview(matview, schema=schema_name):
-    # Create the matview
-    op.create_replaceable_object(matview, schema=schema)
-    # Create any indices on the matview
-    for index in matview.__table__.indexes:
-        op.create_index(
-            index_name=index.name,
-            table_name=index.table.name,
-            columns=[col.name for col in index.columns],
-            unique=index.unique,
-            schema=schema,
-        )
+    create_view_or_matview(CrmpNetworkGeoserver, schema=schema_name)
 
 
 def upgrade():
     drop_dependent_objects()
-    drop_matview(OldCollapsedVariables)
-    create_matview(NewCollapsedVariables)
+    drop_view_or_matview(OldCollapsedVariables)
+    create_view_or_matview(NewCollapsedVariables)
     create_dependent_objects()
 
 
 def downgrade():
     drop_dependent_objects()
-    drop_matview(NewCollapsedVariables)
-    create_matview(OldCollapsedVariables)
+    drop_view_or_matview(NewCollapsedVariables)
+    create_view_or_matview(OldCollapsedVariables)
     create_dependent_objects()

--- a/pycds/context.py
+++ b/pycds/context.py
@@ -1,4 +1,40 @@
 import os
+import re
+
+
+def split_on(sep):
+    def f(s):
+        if s == "":
+            return []
+        return re.split(fr"\s*{sep}\s*", s)
+    return f
+
+
+def parse_standard_table_privileges(stp):
+    """A standard table privilege spec is a string of the form
+        role: priv, priv, priv, ...; role: priv, priv, priv, ...; ...
+    The named role is granted the privileges listed after the colon following it.
+    Privileges are separated by commas. A sequence of such role-priv items is separated
+    by semicolons.
+    """
+    split_items = split_on(';')
+    split_item = split_on(':')
+
+    def split_privs(rp):
+        return rp[0], split_on(',')(rp[1])
+
+    return list(map(split_privs, map(split_item, split_items(stp))))
+
+
+def get_standard_table_privileges(
+    default_privs="inspector: SELECT; viewer: SELECT; steward: ALL"
+):
+    """Get and parse an environment variable defining the standard privileges to be
+    applied to new table-like) objects (tables, views, matviews.
+    """
+    env = os.environ.get("PYCDS_STANDARD_TABLE_PRIVS", default_privs)
+    return parse_standard_table_privileges(env)
+
 
 
 def get_schema_name():

--- a/pycds/context.py
+++ b/pycds/context.py
@@ -6,7 +6,8 @@ def split_on(sep):
     def f(s):
         if s == "":
             return []
-        return re.split(fr"\s*{sep}\s*", s)
+        return re.split(rf"\s*{sep}\s*", s)
+
     return f
 
 
@@ -17,24 +18,23 @@ def parse_standard_table_privileges(stp):
     Privileges are separated by commas. A sequence of such role-priv items is separated
     by semicolons.
     """
-    split_items = split_on(';')
-    split_item = split_on(':')
+    split_items = split_on(";")
+    split_item = split_on(":")
 
     def split_privs(rp):
-        return rp[0], split_on(',')(rp[1])
+        return rp[0], split_on(",")(rp[1])
 
     return list(map(split_privs, map(split_item, split_items(stp))))
 
 
 def get_standard_table_privileges(
-    default_privs="inspector: SELECT; viewer: SELECT; steward: ALL"
+    default_privs="inspector: SELECT; viewer: SELECT; steward: ALL",
 ):
     """Get and parse an environment variable defining the standard privileges to be
     applied to new table-like) objects (tables, views, matviews.
     """
     env = os.environ.get("PYCDS_STANDARD_TABLE_PRIVS", default_privs)
     return parse_standard_table_privileges(env)
-
 
 
 def get_schema_name():

--- a/pycds/sqlalchemy/ddl_extensions/__init__.py
+++ b/pycds/sqlalchemy/ddl_extensions/__init__.py
@@ -8,6 +8,7 @@ The definition pattern is:
 - Define a compilation (implementation) of the command.
 """
 from ..ddl_extensions.function import CreateFunction, DropFunction
+from ..ddl_extensions.grant import GrantTablePrivileges
 from ..ddl_extensions.materialized_view import (
     CreateMaterializedView,
     DropMaterializedView,

--- a/pycds/sqlalchemy/ddl_extensions/grant.py
+++ b/pycds/sqlalchemy/ddl_extensions/grant.py
@@ -8,11 +8,13 @@ from sqlalchemy.ext import compiler
 
 class GrantTablePrivileges(DDLElement):
     """"""
+
     def __init__(self, privileges, table_name, role_specification, schema=None):
         self.privileges = privileges
         self.table_name = table_name
         self.role_specification = role_specification
         self.schema = schema
+
 
 @compiler.compiles(GrantTablePrivileges)
 def compile_grant_table_privileges(element, compiler, **kw):
@@ -20,4 +22,3 @@ def compile_grant_table_privileges(element, compiler, **kw):
     schema_prefix = f"{element.schema}." if element.schema is not None else ""
     object_id = f"{schema_prefix}{element.table_name}"
     return f"GRANT {privileges} ON {object_id} TO {element.role_specification}"
-

--- a/pycds/sqlalchemy/ddl_extensions/grant.py
+++ b/pycds/sqlalchemy/ddl_extensions/grant.py
@@ -1,0 +1,23 @@
+"""
+DDLElements for SQL GRANT statements.
+"""
+
+from sqlalchemy.schema import DDLElement
+from sqlalchemy.ext import compiler
+
+
+class GrantTablePrivileges(DDLElement):
+    """"""
+    def __init__(self, privileges, table_name, role_specification, schema=None):
+        self.privileges = privileges
+        self.table_name = table_name
+        self.role_specification = role_specification
+        self.schema = schema
+
+@compiler.compiles(GrantTablePrivileges)
+def compile_grant_table_privileges(element, compiler, **kw):
+    privileges = ", ".join(element.privileges)
+    schema_prefix = f"{element.schema}." if element.schema is not None else ""
+    object_id = f"{schema_prefix}{element.table_name}"
+    return f"GRANT {privileges} ON {object_id} TO {element.role_specification}"
+

--- a/pycds/sqlalchemy/ddl_extensions/grant.py
+++ b/pycds/sqlalchemy/ddl_extensions/grant.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext import compiler
 
 
 class GrantTablePrivileges(DDLElement):
-    """"""
+    """SQLAlchemy implementation of the GRANT directive"""
 
     def __init__(self, privileges, table_name, role_specification, schema=None):
         self.privileges = privileges

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import testing.postgresql
 
 import pycds
 import pycds.alembic.info
+from pycds.context import get_standard_table_privileges
 
 
 def pytest_runtest_setup():
@@ -54,7 +55,7 @@ def set_up_db_cluster(db_uri, user="testuser"):
     # TODO: See if more things, e.g., extensions, languages can be done here.
     engine = create_engine(db_uri)
 
-    for role in ("inspector", "viewer", "steward"):
+    for role, _ in get_standard_table_privileges():
         engine.execute(f"CREATE ROLE {role}")
     engine.execute(f"CREATE ROLE {pycds.get_su_role_name()} WITH SUPERUSER NOINHERIT;")
     engine.execute(f"CREATE USER {user};")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,8 @@ def set_up_db_cluster(db_uri, user="testuser"):
     # TODO: See if more things, e.g., extensions, languages can be done here.
     engine = create_engine(db_uri)
 
+    for role in ("inspector", "viewer", "steward"):
+        engine.execute(f"CREATE ROLE {role}")
     engine.execute(f"CREATE ROLE {pycds.get_su_role_name()} WITH SUPERUSER NOINHERIT;")
     engine.execute(f"CREATE USER {user};")
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,0 +1,17 @@
+import pytest
+from pycds.context import parse_standard_table_privileges
+
+
+@pytest.mark.parametrize(
+    "stp, expected",
+    [
+        ("", []),
+        (
+            "admin: ALL; user: SELECT,INSERT",
+            [("admin", ["ALL"]), ("user", ["SELECT", "INSERT"])],
+        ),
+    ],
+)
+def test_parse_standard_table_privileges(stp, expected):
+    result = list(parse_standard_table_privileges(stp))
+    assert result == expected


### PR DESCRIPTION
Resolves #205 

Also DRYs up migration scripts that create or drop views or matviews.