### PR TITLE
Add columns for earliest and latest timestamps to vars_per_history_mv

### DIFF
--- a/docs/dev-notes/migrations/create-new-migration.md
+++ b/docs/dev-notes/migrations/create-new-migration.md
@@ -35,7 +35,17 @@ Instructions:
    2. Do this for both upgrade and downgrade functions in the script!
    3. Data and schema migrations are not handled separately and should be included as part of the migration where applicable.
 
-4. Write some tests for the migration, including tests for the data migration where applicable. Examples can be found in the existing code.
+4. Write some tests for the migration, including tests for the data migration where applicable. Examples can be found in the existing code. 
+    1. Note: if you update a view or matview, import it explicitly from the latest migration, such as
+        ```python 
+        from pycds.orm.native_matviews.version_3505750d3416 import VarsPerHistory
+        ```
+        instead of 
+    
+        ```python 
+        from pycds.orm.native_matviews import VarsPerHistory
+        ```
+        Importing without specifying a specific migration file will give you an arbitrary member of the set of all versions of VarsPerHistory, not necessarily the latest migration. In this case tests will be done with an up to date database, but possibly an out of date ORM.
 
 5. Commit the new migration script and its tests to the repo.
 

--- a/docs/dev-notes/migrations/create-new-migration.md
+++ b/docs/dev-notes/migrations/create-new-migration.md
@@ -36,16 +36,7 @@ Instructions:
    3. Data and schema migrations are not handled separately and should be included as part of the migration where applicable.
 
 4. Write some tests for the migration, including tests for the data migration where applicable. Examples can be found in the existing code. 
-    1. Note: if you update a view or matview, import it explicitly from the latest migration, such as
-        ```python 
-        from pycds.orm.native_matviews.version_3505750d3416 import VarsPerHistory
-        ```
-        instead of 
-    
-        ```python 
-        from pycds.orm.native_matviews import VarsPerHistory
-        ```
-        Importing without specifying a specific migration file will give you an arbitrary member of the set of all versions of VarsPerHistory, not necessarily the latest migration. In this case tests will be done with an up to date database, but possibly an out of date ORM.
+    1. Note: if you update a view or matview, you need to update __init__.py in the corresponding directory to indicate which version of the object is the most recent.
 
 5. Commit the new migration script and its tests to the repo.
 

--- a/pycds/alembic/versions/3505750d3416_add_start_stop_times_to_vars_per_.py
+++ b/pycds/alembic/versions/3505750d3416_add_start_stop_times_to_vars_per_.py
@@ -1,0 +1,67 @@
+"""Add start/stop times to vars_per_history_mv
+
+Revision ID: 3505750d3416
+Revises: e4d17c4a1a0c
+Create Date: 2024-02-27 12:30:37.975526
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from pycds.context import get_su_role_name
+
+#matview being upgraded
+from pycds.orm.native_matviews.version_7a3b247c577b import (
+    VarsPerHistory as old_varsperhistory,
+)
+from pycds.orm.native_matviews.version_3505750d3416 import (
+    VarsPerHistory as new_varsperhistory,
+)
+
+# view and matview that depend on the one being upgraded or downgraded,
+# and need to be replaced as well
+from pycds.orm.views.version_6cb393f711c3 import CrmpNetworkGeoserver
+from pycds.orm.native_matviews.version_fecff1a73d7e import CollapsedVariables
+
+# revision identifiers, used by Alembic.
+revision = "3505750d3416"
+down_revision = "efde19ea4f52"
+branch_labels = None
+depends_on = None    
+    
+    
+def upgrade():
+    op.set_role(get_su_role_name())
+    
+    #drop dependent objects
+    op.drop_replaceable_object(CrmpNetworkGeoserver)
+    op.drop_replaceable_object(CollapsedVariables)
+    
+    #upgrade VarsPerHistory
+    op.drop_replaceable_object(old_varsperhistory)
+    op.create_replaceable_object(new_varsperhistory)
+    
+    #restore dependent objects
+    op.create_replaceable_object(CollapsedVariables)
+    op.create_replaceable_object(CrmpNetworkGeoserver)
+
+    op.reset_role()
+
+
+def downgrade():
+    op.set_role(get_su_role_name())
+    
+    #drop dependent objects
+    op.drop_replaceable_object(CrmpNetworkGeoserver)
+    op.drop_replaceable_object(CollapsedVariables)
+    
+    #downgrade VarsPerHistory
+    op.drop_replaceable_object(new_varsperhistory)
+    op.create_replaceable_object(old_varsperhistory)
+    
+    #restore dependent objects
+    op.create_replaceable_object(CollapsedVariables)
+    op.create_replaceable_object(CrmpNetworkGeoserver)
+
+    op.reset_role()
+

--- a/pycds/alembic/versions/3505750d3416_add_start_stop_times_to_vars_per_.py
+++ b/pycds/alembic/versions/3505750d3416_add_start_stop_times_to_vars_per_.py
@@ -8,9 +8,9 @@ Create Date: 2024-02-27 12:30:37.975526
 from alembic import op
 import sqlalchemy as sa
 
-from pycds.context import get_su_role_name
+from pycds.context import get_su_role_name, get_schema_name
 
-#matview being upgraded
+# matview being upgraded
 from pycds.orm.native_matviews.version_7a3b247c577b import (
     VarsPerHistory as old_varsperhistory,
 )
@@ -27,40 +27,48 @@ from pycds.orm.native_matviews.version_fecff1a73d7e import CollapsedVariables
 revision = "3505750d3416"
 down_revision = "efde19ea4f52"
 branch_labels = None
-depends_on = None    
+depends_on = None
+
 
 # drop other objects that depend on the view being upgraded
 def drop_dependent_objects():
     op.drop_replaceable_object(CrmpNetworkGeoserver)
     op.drop_replaceable_object(CollapsedVariables)
 
-#recreate other objects that depend on the view being upgraded
+
+# recreate other objects that depend on the view being upgraded
 def create_dependent_objects():
     op.create_replaceable_object(CollapsedVariables)
     op.create_replaceable_object(CrmpNetworkGeoserver)
-    op.create_index_if_not_exists(index_name = "collapsed_vars_idx", 
-                                  table_name = "collapsed_vars_mv", 
-                                  columns = ["history_id"],
-                                  unique = False,
-                                  schema = "crmp")
-                                  
+    op.create_index_if_not_exists(
+        index_name="collapsed_vars_idx",
+        table_name="collapsed_vars_mv",
+        columns=["history_id"],
+        unique=False,
+        schema=get_schema_name(),
+    )
+
+
 def create_var_hist_index():
-    op.create_index_if_not_exists(index_name = "var_hist_idx",
-                                  table_name = "vars_per_history_mv",
-                                  columns = ["history_id", "vars_id"],
-                                  unique = False,
-                                  schema = "crmp")
+    op.create_index_if_not_exists(
+        index_name="var_hist_idx",
+        table_name="vars_per_history_mv",
+        columns=["history_id", "vars_id"],
+        unique=False,
+        schema=get_schema_name(),
+    )
+
 
 def upgrade():
     op.set_role(get_su_role_name())
-    
+
     drop_dependent_objects()
-    
+
     op.drop_replaceable_object(old_varsperhistory)
     op.create_replaceable_object(new_varsperhistory)
-    #why does this have to be done explicitly?
+    # why does this have to be done explicitly?
     create_var_hist_index()
-    
+
     create_dependent_objects()
 
     op.reset_role()
@@ -70,12 +78,11 @@ def downgrade():
     op.set_role(get_su_role_name())
 
     drop_dependent_objects()
-    
+
     op.drop_replaceable_object(new_varsperhistory)
     op.create_replaceable_object(old_varsperhistory)
     create_var_hist_index()
-    
+
     create_dependent_objects()
 
     op.reset_role()
-

--- a/pycds/alembic/versions/3505750d3416_add_start_stop_times_to_vars_per_.py
+++ b/pycds/alembic/versions/3505750d3416_add_start_stop_times_to_vars_per_.py
@@ -28,40 +28,54 @@ revision = "3505750d3416"
 down_revision = "efde19ea4f52"
 branch_labels = None
 depends_on = None    
-    
-    
+
+# drop other objects that depend on the view being upgraded
+def drop_dependent_objects():
+    op.drop_replaceable_object(CrmpNetworkGeoserver)
+    op.drop_replaceable_object(CollapsedVariables)
+
+#recreate other objects that depend on the view being upgraded
+def create_dependent_objects():
+    op.create_replaceable_object(CollapsedVariables)
+    op.create_replaceable_object(CrmpNetworkGeoserver)
+    op.create_index_if_not_exists(index_name = "collapsed_vars_idx", 
+                                  table_name = "collapsed_vars_mv", 
+                                  columns = ["history_id"],
+                                  unique = False,
+                                  schema = "crmp")
+                                  
+def create_var_hist_index():
+    op.create_index_if_not_exists(index_name = "var_hist_idx",
+                                  table_name = "vars_per_history_mv",
+                                  columns = ["history_id", "vars_id"],
+                                  unique = False,
+                                  schema = "crmp")
+
 def upgrade():
     op.set_role(get_su_role_name())
     
-    #drop dependent objects
-    op.drop_replaceable_object(CrmpNetworkGeoserver)
-    op.drop_replaceable_object(CollapsedVariables)
+    drop_dependent_objects()
     
-    #upgrade VarsPerHistory
     op.drop_replaceable_object(old_varsperhistory)
     op.create_replaceable_object(new_varsperhistory)
+    #why does this have to be done explicitly?
+    create_var_hist_index()
     
-    #restore dependent objects
-    op.create_replaceable_object(CollapsedVariables)
-    op.create_replaceable_object(CrmpNetworkGeoserver)
+    create_dependent_objects()
 
     op.reset_role()
 
 
 def downgrade():
     op.set_role(get_su_role_name())
+
+    drop_dependent_objects()
     
-    #drop dependent objects
-    op.drop_replaceable_object(CrmpNetworkGeoserver)
-    op.drop_replaceable_object(CollapsedVariables)
-    
-    #downgrade VarsPerHistory
     op.drop_replaceable_object(new_varsperhistory)
     op.create_replaceable_object(old_varsperhistory)
+    create_var_hist_index()
     
-    #restore dependent objects
-    op.create_replaceable_object(CollapsedVariables)
-    op.create_replaceable_object(CrmpNetworkGeoserver)
+    create_dependent_objects()
 
     op.reset_role()
 

--- a/pycds/database.py
+++ b/pycds/database.py
@@ -5,7 +5,7 @@ from pycds.context import get_schema_name
 
 
 def check_migration_version(
-    executor, schema_name=get_schema_name(), version="efde19ea4f52"
+    executor, schema_name=get_schema_name(), version="3505750d3416"
 ):
     """Check that the migration version of the database schema is compatible
     with the current version of this package.

--- a/pycds/orm/native_matviews/__init__.py
+++ b/pycds/orm/native_matviews/__init__.py
@@ -21,7 +21,7 @@ this set of views. Following any PyCDS release, further migrations and further
 releases will "freeze" later sets of views.
 """
 
-from .version_7a3b247c577b import VarsPerHistory
+from .version_3505750d3416 import VarsPerHistory
 from .version_96729d6db8b3 import ClimoObsCount
 from .version_bf366199f463 import StationObservationStats
 from .version_fecff1a73d7e import CollapsedVariables

--- a/pycds/orm/native_matviews/version_3505750d3416.py
+++ b/pycds/orm/native_matviews/version_3505750d3416.py
@@ -1,0 +1,45 @@
+from sqlalchemy import Index, Column, Integer, Date, func
+from sqlalchemy.orm import Query
+from pycds.alembic.extensions.replaceable_objects import ReplaceableNativeMatview
+from pycds.orm.tables import Obs
+from pycds.orm.view_base import make_declarative_base
+
+
+Base = make_declarative_base()
+
+
+class VarsPerHistory(Base, ReplaceableNativeMatview):
+    """This materialized view speeds up the PDP and station data
+    portal by linking variables to stations, rather than needing
+    to query the very large obs_raw table to find what what variables
+    are associated with a station over what timespan.
+    
+    Compared to the previous version of this view, this version
+    adds the earliest and latest timestamps data is recorded for a 
+    variable.
+
+    Definition of supporting *view*:
+    SELECT DISTINCT obs_raw.history_id, obs_raw.vars_id, 
+       min(obs_raw.time) AS start_time, max(obs_raw.time) AS end_time
+    FROM obs_raw
+    GROUP BY history_id, vars_id;
+    """
+
+    __tablename__ = "vars_per_history_mv"
+
+    history_id = Column(Integer, primary_key=True)
+    vars_id = Column(Integer, primary_key=True)
+    start_time = Column(Date)
+    end_time = Column(Date)
+
+    __selectable__ = (
+        Query(
+            [Obs.history_id.label("history_id"), 
+             Obs.vars_id.label("vars_id"),
+             func.min(Obs.time).label("start_time"),
+             func.max(Obs.time).label("end_time")]
+        ).group_by(Obs.history_id, Obs.vars_id)
+    ).selectable
+
+
+Index("var_hist_idx", VarsPerHistory.history_id, VarsPerHistory.vars_id)

--- a/pycds/orm/native_matviews/version_3505750d3416.py
+++ b/pycds/orm/native_matviews/version_3505750d3416.py
@@ -13,13 +13,13 @@ class VarsPerHistory(Base, ReplaceableNativeMatview):
     portal by linking variables to stations, rather than needing
     to query the very large obs_raw table to find what what variables
     are associated with a station over what timespan.
-    
+
     Compared to the previous version of this view, this version
-    adds the earliest and latest timestamps data is recorded for a 
+    adds the earliest and latest timestamps data is recorded for a
     variable.
 
     Definition of supporting *view*:
-    SELECT DISTINCT obs_raw.history_id, obs_raw.vars_id, 
+    SELECT DISTINCT obs_raw.history_id, obs_raw.vars_id,
        min(obs_raw.time) AS start_time, max(obs_raw.time) AS end_time
     FROM obs_raw
     GROUP BY history_id, vars_id;
@@ -34,10 +34,12 @@ class VarsPerHistory(Base, ReplaceableNativeMatview):
 
     __selectable__ = (
         Query(
-            [Obs.history_id.label("history_id"), 
-             Obs.vars_id.label("vars_id"),
-             func.min(Obs.time).label("start_time"),
-             func.max(Obs.time).label("end_time")]
+            [
+                Obs.history_id.label("history_id"),
+                Obs.vars_id.label("vars_id"),
+                func.min(Obs.time).label("start_time"),
+                func.max(Obs.time).label("end_time"),
+            ]
         ).group_by(Obs.history_id, Obs.vars_id)
     ).selectable
 

--- a/pycds/orm/native_matviews/version_3505750d3416.py
+++ b/pycds/orm/native_matviews/version_3505750d3416.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Index, Column, Integer, Date, func
+from sqlalchemy import Index, Column, Integer, DateTime, func
 from sqlalchemy.orm import Query
 from pycds.alembic.extensions.replaceable_objects import ReplaceableNativeMatview
 from pycds.orm.tables import Obs
@@ -29,8 +29,8 @@ class VarsPerHistory(Base, ReplaceableNativeMatview):
 
     history_id = Column(Integer, primary_key=True)
     vars_id = Column(Integer, primary_key=True)
-    start_time = Column(Date)
-    end_time = Column(Date)
+    start_time = Column(DateTime)
+    end_time = Column(DateTime)
 
     __selectable__ = (
         Query(

--- a/tests/alembic_migrations/test_check_migration_version.py
+++ b/tests/alembic_migrations/test_check_migration_version.py
@@ -7,7 +7,7 @@ from pycds.database import check_migration_version
 
 
 def test_get_current_head():
-    assert get_current_head() == "efde19ea4f52"
+    assert get_current_head() == "3505750d3416"
 
 
 @pytest.mark.usefixtures("new_db_left")

--- a/tests/alembic_migrations/versions/v_3505750d3416_add_start_stop_times_to_vars_per/conftest.py
+++ b/tests/alembic_migrations/versions/v_3505750d3416_add_start_stop_times_to_vars_per/conftest.py
@@ -1,0 +1,29 @@
+import pytest
+from sqlalchemy.orm import sessionmaker
+from ....alembicverify_util import prepare_schema_from_migrations
+from ....helpers import insert_crmp_data
+
+
+@pytest.fixture(scope="function")
+def prepared_schema_from_migrations_left(uri_left, alembic_config_left, db_setup):
+    engine, script = prepare_schema_from_migrations(
+        uri_left,
+        alembic_config_left,
+        db_setup=db_setup,
+        revision="3505750d3416",
+    )
+
+    yield engine, script
+
+    engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def sesh_with_large_data(prepared_schema_from_migrations_left):
+    engine, script = prepared_schema_from_migrations_left
+    sesh = sessionmaker(bind=engine)()
+    insert_crmp_data(sesh)
+
+    yield sesh
+
+    sesh.close()

--- a/tests/alembic_migrations/versions/v_3505750d3416_add_start_stop_times_to_vars_per/test_smoke.py
+++ b/tests/alembic_migrations/versions/v_3505750d3416_add_start_stop_times_to_vars_per/test_smoke.py
@@ -17,6 +17,7 @@ from .. import check_matviews
 
 matview_defns = {"vars_per_history_mv": {"indexes": {"var_hist_idx"}}}
 
+
 @pytest.mark.usefixtures("new_db_left")
 def test_upgrade(prepared_schema_from_migrations_left, schema_name):
     """Test the schema migration to version 3505750d3416."""
@@ -24,9 +25,8 @@ def test_upgrade(prepared_schema_from_migrations_left, schema_name):
     # Set up database to version 3505750d3416
     engine, script = prepared_schema_from_migrations_left
 
-    
     # this check only confirms that the matview and its index exist;
-    # it's hard to directly check the columns via sqlalchemy. 
+    # it's hard to directly check the columns via sqlalchemy.
     # Behavioural tests address this elsewhere.
     check_matviews(engine, matview_defns, schema_name, matviews_present=True)
 
@@ -44,6 +44,6 @@ def test_downgrade(
     command.downgrade(alembic_config_left, "-1")
 
     # this check only confirms that the matview and its index exist;
-    # it's hard to directly check the columns via sqlalchemy. 
+    # it's hard to directly check the columns via sqlalchemy.
     # Behavioural tests address this elsewhere.
     check_matviews(engine, matview_defns, schema_name, matviews_present=True)

--- a/tests/alembic_migrations/versions/v_3505750d3416_add_start_stop_times_to_vars_per/test_smoke.py
+++ b/tests/alembic_migrations/versions/v_3505750d3416_add_start_stop_times_to_vars_per/test_smoke.py
@@ -1,0 +1,49 @@
+"""Smoke tests:
+- Upgrade adds columns to matview
+- Downgrade drops columns from matview
+"""
+
+# -*- coding: utf-8 -*-
+import logging
+import pytest
+from alembic import command
+from sqlalchemy import inspect
+from pycds.database import get_schema_item_names
+
+logger = logging.getLogger("tests")
+
+
+from .. import check_matviews
+
+matview_defns = {"vars_per_history_mv": {"indexes": {"var_hist_idx"}}}
+
+@pytest.mark.usefixtures("new_db_left")
+def test_upgrade(prepared_schema_from_migrations_left, schema_name):
+    """Test the schema migration to version 3505750d3416."""
+
+    # Set up database to version 3505750d3416
+    engine, script = prepared_schema_from_migrations_left
+
+    
+    # this check only confirms that the matview and its index exist;
+    # it's hard to directly check the columns via sqlalchemy. 
+    # Behavioural tests address this elsewhere.
+    check_matviews(engine, matview_defns, schema_name, matviews_present=True)
+
+
+@pytest.mark.usefixtures("new_db_left")
+def test_downgrade(
+    prepared_schema_from_migrations_left, alembic_config_left, schema_name
+):
+    """Test the schema migration from 3505750d3416 to efde19ea4f52."""
+
+    # Set up database to version efde19ea4f52
+    engine, script = prepared_schema_from_migrations_left
+
+    # Run downgrade migration
+    command.downgrade(alembic_config_left, "-1")
+
+    # this check only confirms that the matview and its index exist;
+    # it's hard to directly check the columns via sqlalchemy. 
+    # Behavioural tests address this elsewhere.
+    check_matviews(engine, matview_defns, schema_name, matviews_present=True)

--- a/tests/behavioural/native_matviews/test_vars_per_history.py
+++ b/tests/behavioural/native_matviews/test_vars_per_history.py
@@ -1,5 +1,7 @@
 import pytest
 import sqlalchemy
+from sqlalchemy import inspect
+from datetime import datetime
 from pycds.orm.native_matviews import VarsPerHistory
 
 
@@ -34,6 +36,50 @@ def test_matview_content(sesh_with_large_data):
     }
     result_pairs = {(row.history_id, row.vars_id) for row in q.all()}
     assert expected_pairs <= result_pairs
+
+
+#test start and stop times on newest revision
+@pytest.mark.usefixtures("new_db_left")
+# try explicitly set the migration.
+@pytest.mark.parametrize(
+    "prepared_schema_from_migrations_left",
+    ("3505750d3416",),
+    indirect=True,
+    )
+def test_matview_dates(sesh_with_large_data):
+    #version = sesh_with_large_data.execute("SELECT * FROM crmp.alembic_version")
+    #print(version.one())
+    # prints 3505750d3416, which is correct
+    
+    q = sesh_with_large_data.query(VarsPerHistory)
+    assert q.count() == 0
+    
+    sesh_with_large_data.execute(VarsPerHistory.refresh())
+    assert q.count() > 0
+    
+    #raw = sesh_with_large_data.execute("SELECT * FROM crmp.vars_per_history_mv")
+    #print(raw.all()[0])
+    #includes a start_time and end_time, which is correct
+
+    
+    expected_timestamps = {
+        (8316, 555, datetime(1980, 1, 1), datetime(1980, 2, 1)),
+        (2716, 497, datetime(1980, 1, 1), datetime(1980, 2, 1)),
+        (5716, 526, datetime(1980, 1, 1), datetime(1980, 2, 1)),
+        (1816, 556, datetime(1980, 1, 1), datetime(1980, 2, 1)),
+        (1616, 556, datetime(1980, 1, 1), datetime(1980, 2, 1)),
+        (7716, 526, datetime(1980, 1, 1), datetime(1980, 2, 1)),
+        (5916, 526, datetime(1980, 1, 1), datetime(1980, 2, 1)),
+        (8016, 528, datetime(1980, 1, 1), datetime(1980, 2, 1)),
+        (3516, 562, datetime(1980, 1, 1), datetime(1980, 2, 1)),
+        (7816, 527, datetime(1980, 1, 1), datetime(1980, 2, 1)),
+        (5816, 519, datetime(1980, 1, 1), datetime(1980, 2, 1)),
+    }
+    
+    #error here - start_time does not exist - why??
+    result_timestamps = {(row.history_id, row.vars_id, row.start_time, row.end_time) for row in q.all()}
+    
+    assert expected_timestamps <= result_timestamps
 
 
 @pytest.mark.usefixtures("new_db_left")

--- a/tests/behavioural/native_matviews/test_vars_per_history.py
+++ b/tests/behavioural/native_matviews/test_vars_per_history.py
@@ -2,7 +2,7 @@ import pytest
 import sqlalchemy
 from sqlalchemy import inspect
 from datetime import datetime
-from pycds.orm.native_matviews.version_3505750d3416 import VarsPerHistory
+from pycds.orm.native_matviews import VarsPerHistory
 
 
 @pytest.mark.usefixtures("new_db_left")

--- a/tests/behavioural/native_matviews/test_vars_per_history.py
+++ b/tests/behavioural/native_matviews/test_vars_per_history.py
@@ -2,7 +2,7 @@ import pytest
 import sqlalchemy
 from sqlalchemy import inspect
 from datetime import datetime
-from pycds.orm.native_matviews import VarsPerHistory
+from pycds.orm.native_matviews.version_3505750d3416 import VarsPerHistory
 
 
 @pytest.mark.usefixtures("new_db_left")
@@ -38,47 +38,49 @@ def test_matview_content(sesh_with_large_data):
     assert expected_pairs <= result_pairs
 
 
-#test start and stop times on newest revision
+# test start and stop times on newest revision
 @pytest.mark.usefixtures("new_db_left")
-# try explicitly set the migration.
-@pytest.mark.parametrize(
-    "prepared_schema_from_migrations_left",
-    ("3505750d3416",),
-    indirect=True,
-    )
 def test_matview_dates(sesh_with_large_data):
-    #version = sesh_with_large_data.execute("SELECT * FROM crmp.alembic_version")
-    #print(version.one())
-    # prints 3505750d3416, which is correct
-    
     q = sesh_with_large_data.query(VarsPerHistory)
     assert q.count() == 0
-    
+
     sesh_with_large_data.execute(VarsPerHistory.refresh())
     assert q.count() > 0
-    
-    #raw = sesh_with_large_data.execute("SELECT * FROM crmp.vars_per_history_mv")
-    #print(raw.all()[0])
-    #includes a start_time and end_time, which is correct
 
-    
     expected_timestamps = {
-        (8316, 555, datetime(1980, 1, 1), datetime(1980, 2, 1)),
-        (2716, 497, datetime(1980, 1, 1), datetime(1980, 2, 1)),
-        (5716, 526, datetime(1980, 1, 1), datetime(1980, 2, 1)),
-        (1816, 556, datetime(1980, 1, 1), datetime(1980, 2, 1)),
-        (1616, 556, datetime(1980, 1, 1), datetime(1980, 2, 1)),
-        (7716, 526, datetime(1980, 1, 1), datetime(1980, 2, 1)),
-        (5916, 526, datetime(1980, 1, 1), datetime(1980, 2, 1)),
-        (8016, 528, datetime(1980, 1, 1), datetime(1980, 2, 1)),
-        (3516, 562, datetime(1980, 1, 1), datetime(1980, 2, 1)),
-        (7816, 527, datetime(1980, 1, 1), datetime(1980, 2, 1)),
-        (5816, 519, datetime(1980, 1, 1), datetime(1980, 2, 1)),
+        (6116, 526, datetime(1969, 6, 29, 0, 0), datetime(1970, 9, 28, 0, 0)),
+        (8216, 526, datetime(1975, 8, 5, 0, 0), datetime(1975, 8, 5, 0, 0)),
+        (6716, 528, datetime(1969, 12, 29, 0, 0), datetime(1971, 1, 29, 0, 0)),
+        (8516, 544, datetime(2012, 9, 16, 6, 0), datetime(2012, 9, 16, 6, 0)),
+        (
+            1716,
+            559,
+            datetime(2000, 1, 31, 23, 59, 59),
+            datetime(2000, 12, 31, 23, 59, 59),
+        ),
+        (
+            1816,
+            556,
+            datetime(2000, 1, 31, 23, 59, 59),
+            datetime(2000, 12, 31, 23, 59, 59),
+        ),
+        (3416, 437, datetime(2015, 9, 24, 10, 0), datetime(2015, 9, 24, 16, 0)),
+        (8316, 552, datetime(2013, 8, 22, 4, 0), datetime(2013, 8, 22, 10, 0)),
+        (1916, 494, datetime(2006, 9, 15, 0, 0), datetime(2006, 11, 3, 0, 0)),
+        (
+            1616,
+            558,
+            datetime(2000, 1, 31, 23, 59, 59),
+            datetime(2000, 12, 31, 23, 59, 59),
+        ),
+        (6316, 527, datetime(1977, 7, 6, 0, 0), datetime(1977, 10, 19, 0, 0)),
+        (3616, 434, datetime(2015, 9, 9, 3, 0), datetime(2015, 9, 24, 16, 0)),
     }
-    
-    #error here - start_time does not exist - why??
-    result_timestamps = {(row.history_id, row.vars_id, row.start_time, row.end_time) for row in q.all()}
-    
+
+    result_timestamps = {
+        (row.history_id, row.vars_id, row.start_time, row.end_time) for row in q.all()
+    }
+
     assert expected_timestamps <= result_timestamps
 
 


### PR DESCRIPTION
This PR adds two additional columns to the `vars_per_history_mv` materialized view - `start_time` and `end_time`.  This is intended to support the station data portal preview page, as fetching this information by query to `obs_raw` is prohibitively slow.

Encountered an odd wrinkle in the test setup for this one: the behavioral tests were loading the _HEAD_ version of the database, but an _older_ version of the ORM, leading to some very confusing behaviour! Thanks to @Nospamas for figuring out what was going on there; I have added a note to the documentation that one should load precisely the version of the ORM one wants for testing.

If a reviewer would like to look at a nearly-full-size database to which this migration has been applied, there is one on dbtest02:
```sql
$ psql  -h dbtest02.pcic.uvic.ca -d crmp_brin -U crmp
Password for user crmp:  #same as live database -  it's in TPM

psql (12.18 (Ubuntu 12.18-0ubuntu0.20.04.1), server 13.12)
WARNING: psql major version 12, server major version 13.
         Some psql features might not work.
Type "help" for help.

crmp_brin=> SELECT * FROM vars_per_history_mv LIMIT 5;
 history_id | vars_id |     start_time      |      end_time       
------------+---------+---------------------+---------------------
        404 |     429 | 1984-07-01 00:00:00 | 1996-11-30 00:00:00
        404 |     430 | 1984-07-01 00:00:00 | 1996-11-30 00:00:00
        404 |     431 | 1984-07-01 00:00:00 | 1996-11-30 00:00:00
        404 |     432 | 1984-07-01 00:00:00 | 1996-11-30 00:00:00
        404 |     559 | 2000-01-31 23:59:59 | 2000-12-31 23:59:59
(5 rows)
```

Resolve #209 