### PR TITLE
Make migrations of manual matviews (tables) to native matviews conditional

### DIFF
--- a/.github/workflows/code-format-check.yml
+++ b/.github/workflows/code-format-check.yml
@@ -1,0 +1,31 @@
+name: Code format check
+
+on: push
+
+jobs:
+  test:
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Install project
+        run: |
+          # We only need Black, and we want to use the project-specific version.
+          # (Defaults in Black change from time to time and we want only to deal with
+          # the consequences, if any, on our own schedule.)
+          poetry install --only dev
+
+      - name: Run check
+        run: poetry run black . --check

--- a/.github/workflows/code-format-check.yml
+++ b/.github/workflows/code-format-check.yml
@@ -3,7 +3,7 @@ name: Code format check
 on: push
 
 jobs:
-  test:
+  check:
 
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -54,6 +54,3 @@ jobs:
       run: |
         poetry run pytest -m "not slow" -v --tb=short tests
 
-    - name: Code format check
-      if: ${{ matrix.python-version == '3.8' }}
-      run: poetry run black . --check

--- a/pycds/alembic/versions/bf366199f463_convert_station_obs_stats_mv_to_native_.py
+++ b/pycds/alembic/versions/bf366199f463_convert_station_obs_stats_mv_to_native_.py
@@ -69,32 +69,28 @@ def upgrade():
 
 
 def downgrade():
-    engine = op.get_bind().engine
-    if matview_exists(
-        engine, StationObservationStatsMatview.__tablename__, schema=schema_name
-    ):
-        #  We could do this with a DROP ... CASCADE, but I like to be sure exactly what
-        #  I am dropping.
-        drop_dependent_objects()
+    #  We could do this with a DROP ... CASCADE, but I like to be sure exactly what
+    #  I am dropping.
+    drop_dependent_objects()
 
-        # Drop real native matview and replace with fake matview table
-        drop_matview(StationObservationStatsMatview, schema=schema_name)
-        op.create_table(
-            "station_obs_stats_mv",
-            sa.Column("station_id", sa.Integer(), nullable=False),
-            sa.Column("history_id", sa.Integer(), nullable=True),
-            sa.Column("min_obs_time", sa.DateTime(), nullable=True),
-            sa.Column("max_obs_time", sa.DateTime(), nullable=True),
-            sa.Column("obs_count", sa.BigInteger(), nullable=True),
-            sa.ForeignKeyConstraint(
-                ["history_id"], [f"{schema_name}.meta_history.history_id"]
-            ),
-            sa.ForeignKeyConstraint(
-                ["station_id"], [f"{schema_name}.meta_station.station_id"]
-            ),
-            schema=schema_name,
-        )
-        create_view(StationObservationStatsView, schema=schema_name)
+    # Drop real native matview and replace with fake matview table
+    drop_matview(StationObservationStatsMatview, schema=schema_name)
+    op.create_table(
+        "station_obs_stats_mv",
+        sa.Column("station_id", sa.Integer(), nullable=False),
+        sa.Column("history_id", sa.Integer(), nullable=True),
+        sa.Column("min_obs_time", sa.DateTime(), nullable=True),
+        sa.Column("max_obs_time", sa.DateTime(), nullable=True),
+        sa.Column("obs_count", sa.BigInteger(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["history_id"], [f"{schema_name}.meta_history.history_id"]
+        ),
+        sa.ForeignKeyConstraint(
+            ["station_id"], [f"{schema_name}.meta_station.station_id"]
+        ),
+        schema=schema_name,
+    )
+    create_view(StationObservationStatsView, schema=schema_name)
 
-        # Restore dependent objects
-        create_dependent_objects()
+    # Restore dependent objects
+    create_dependent_objects()

--- a/pycds/alembic/versions/bf366199f463_convert_station_obs_stats_mv_to_native_.py
+++ b/pycds/alembic/versions/bf366199f463_convert_station_obs_stats_mv_to_native_.py
@@ -44,9 +44,14 @@ def create_dependent_objects():
 
 def upgrade():
     engine = op.get_bind().engine
-    if not matview_exists(
+    if matview_exists(
         engine, StationObservationStatsMatview.__tablename__, schema=schema_name
     ):
+        logger.info(
+            f"A native materialized view '{StationObservationStatsMatview.__tablename__}' "
+            f"already exists in the database; skipping upgrade"
+        )
+    else:
         #  We could do this with a DROP ... CASCADE, but I like to be sure exactly what
         #  I am dropping.
         drop_dependent_objects()

--- a/pycds/database.py
+++ b/pycds/database.py
@@ -1,4 +1,6 @@
 import re
+
+from sqlalchemy import inspect
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.exc import ProgrammingError
 from pycds.context import get_schema_name
@@ -142,3 +144,10 @@ def get_schema_item_names(
     else:
         raise ValueError("invalid item type")
     return {x[0] for x in r.fetchall()}
+
+
+def matview_exists(engine, name, schema=None):
+    # TODO: Use this when we move to SQLA 2.x
+    # matview_names = inspect(engine).get_materialized_view_names(schema=schema)
+    matview_names = get_schema_item_names(engine, "matviews", schema_name=schema)
+    return name in matview_names

--- a/pycds/sqlalchemy/ddl_extensions/materialized_view.py
+++ b/pycds/sqlalchemy/ddl_extensions/materialized_view.py
@@ -36,7 +36,7 @@ def compiles(element, compiler, **kw):
             element.name,
             "AS",
             body,
-            )
+        )
     if element.type_ == "manual":
         # NOTE: No if_not_exists functionality.
         return f"CREATE TABLE {element.name} AS {body}"
@@ -76,7 +76,7 @@ def compiles(element, compiler, **kw):
             "REFRESH MATERIALIZED VIEW",
             element.concurrently and "CONCURRENTLY",
             element.name,
-            )
+        )
     if element.type_ == "manual":
         body = compiler.sql_compiler.process(element.selectable, literal_binds=True)
         return f"TRUNCATE TABLE {element.name}; INSERT INTO {element.name} {body}"

--- a/pycds/sqlalchemy/ddl_extensions/materialized_view.py
+++ b/pycds/sqlalchemy/ddl_extensions/materialized_view.py
@@ -1,10 +1,12 @@
 from sqlalchemy.ext import compiler
+
+from pycds.util import compact_join
 from ..ddl_extensions.view_common import ViewCommonDDL
 
 
 # Native or manual materialized view commands
 #
-# We reduce repetitive code by folding both native and materialized matviews
+# We reduce repetitive code by folding both native and manual matviews
 # into a single command, distinguished by a `type_` parameter. Default type is
 # native. This could also be done by creating separate command classes for
 # native and manual matviews. That seemed unnecessarily wordy and bulky, but one
@@ -14,33 +16,49 @@ from ..ddl_extensions.view_common import ViewCommonDDL
 
 class MaterializedViewDDL(ViewCommonDDL):
     def __init__(self, name, selectable=None, type_="native"):
-        super().__init__(name, selectable)
+        super().__init__(name, selectable=selectable)
         self.type_ = type_
 
 
 class CreateMaterializedView(MaterializedViewDDL):
-    pass
+    def __init__(self, name, selectable=None, type_="native", if_not_exists=False):
+        super().__init__(name, selectable=selectable, type_=type_)
+        self.if_not_exists = if_not_exists
 
 
 @compiler.compiles(CreateMaterializedView)
-def compile(element, compiler, **kw):
+def compiles(element, compiler, **kw):
     body = compiler.sql_compiler.process(element.selectable, literal_binds=True)
     if element.type_ == "native":
-        return f"CREATE MATERIALIZED VIEW {element.name} AS {body}"
+        return compact_join(
+            "CREATE MATERIALIZED VIEW",
+            element.if_not_exists and "IF NOT EXISTS",
+            element.name,
+            "AS",
+            body,
+            )
     if element.type_ == "manual":
+        # NOTE: No if_not_exists functionality.
         return f"CREATE TABLE {element.name} AS {body}"
     raise ValueError(f"Invalid materialized view type '{element.type_}'")
 
 
 class DropMaterializedView(MaterializedViewDDL):
-    pass
+    def __init__(self, name, selectable=None, type_="native", if_exists=False):
+        super().__init__(name, selectable=selectable, type_=type_)
+        self.if_exists = if_exists
 
 
 @compiler.compiles(DropMaterializedView)
-def compile(element, compiler, **kw):
+def compiles(element, compiler, **kw):
     if element.type_ == "native":
-        return f"DROP MATERIALIZED VIEW {element.name}"
+        return compact_join(
+            "DROP MATERIALIZED VIEW",
+            element.if_exists and "IF EXISTS",
+            element.name,
+        )
     if element.type_ == "manual":
+        # NOTE: No if_exists functionality.
         return f"DROP TABLE {element.name}"
     raise ValueError(f"Invalid materialized view type '{element.type_}'")
 
@@ -52,10 +70,13 @@ class RefreshMaterializedView(MaterializedViewDDL):
 
 
 @compiler.compiles(RefreshMaterializedView)
-def compile(element, compiler, **kw):
+def compiles(element, compiler, **kw):
     if element.type_ == "native":
-        concurrently = "CONCURRENTLY" if element.concurrently else ""
-        return f"REFRESH MATERIALIZED VIEW {concurrently} {element.name}"
+        return compact_join(
+            "REFRESH MATERIALIZED VIEW",
+            element.concurrently and "CONCURRENTLY",
+            element.name,
+            )
     if element.type_ == "manual":
         body = compiler.sql_compiler.process(element.selectable, literal_binds=True)
         return f"TRUNCATE TABLE {element.name}; INSERT INTO {element.name} {body}"


### PR DESCRIPTION
Resolves #204 

This PR does what the title says, for the following manual matviews:
- obs_count_per_month_history_mv
- collapsed_vars_mv
- station_obs_stats_mv
- climo_obs_count_mv

It does so by testing whether a native matview of the given name exists, and migrating only if it does not. The converse for the downgrade operation.

This PR also adds the `IF [NOT] EXISTS` syntax to the existing custom SQLAlchemy DDL for `CREATE / DROP MATERIALIZED VIEW` command. This turned out not to be useful in this particular case, but I left it in because it may be useful later.

And it splits out the code format check (Black) into a separate workflow.