### PR TITLE
 #213 Use utility functions when recreating objects to correct permissions.

### DIFF
--- a/pycds/alembic/util.py
+++ b/pycds/alembic/util.py
@@ -19,8 +19,8 @@ def create_matview(obj, **kwargs):
 def create_view_or_matview(obj, schema=None, grant_privs=True, create_indexes=True):
     """Create a view or matview, and optionally create the indexes associated with it."""
     if schema == None:
-        logging.info(
-            f"Warning schema name not set while attempting to create {obj}, this may result in an error if search paths are not set correctly or during testing."
+        logging.warn(
+            f"Schema name not set while attempting to create {obj}, this may result in an error if search paths are not set correctly or during testing."
         )
     op.create_replaceable_object(obj, schema=schema)
     if grant_privs:
@@ -47,8 +47,8 @@ def drop_matview(obj, **kwargs):
 def drop_view_or_matview(obj, schema=None, drop_indexes=True):
     """Drop a view or matview, and optionally drop the indexes associated with it."""
     if schema == None:
-        logging.info(
-            f"Warning schema name not set while attempting to drop {obj}, this may result in an error if search paths are not set correctly or during testing."
+        logging.warn(
+            f"Schema name not set while attempting to drop {obj}, this may result in an error if search paths are not set correctly or during testing."
         )
     if drop_indexes:
         for index in obj.__table__.indexes:

--- a/pycds/alembic/util.py
+++ b/pycds/alembic/util.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Union, Tuple
 
 from sqlalchemy.sql.ddl import DDLElement
@@ -17,6 +18,10 @@ def create_matview(obj, **kwargs):
 
 def create_view_or_matview(obj, schema=None, grant_privs=True, create_indexes=True):
     """Create a view or matview, and optionally create the indexes associated with it."""
+    if schema == None:
+        logging.info(
+            f"Warning schema name not set while attempting to create {obj}, this may result in an error if search paths are not set correctly or during testing."
+        )
     op.create_replaceable_object(obj, schema=schema)
     if grant_privs:
         grant_standard_table_privileges(obj, schema=schema)
@@ -41,6 +46,10 @@ def drop_matview(obj, **kwargs):
 
 def drop_view_or_matview(obj, schema=None, drop_indexes=True):
     """Drop a view or matview, and optionally drop the indexes associated with it."""
+    if schema == None:
+        logging.info(
+            f"Warning schema name not set while attempting to drop {obj}, this may result in an error if search paths are not set correctly or during testing."
+        )
     if drop_indexes:
         for index in obj.__table__.indexes:
             op.drop_index(


### PR DESCRIPTION
 - Updates migration 3505750d3416 to use the correct utility functions.
 - Add warning in utility functions when no schema name is present.