### PR TITLE
Update history FKs in obs_raw_hx not using trigger

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -41,16 +41,19 @@ script_location = pycds/alembic
 sqlalchemy.url = postgresql://metnorth_test:PASSWORD@localhost:30111/metnorth_test
 
 [metnorth-dev-b]
-sqlalchemy.url = postgresql://metnorth_test:PASSWORD@localhost:30112/metnorth_test
+sqlalchemy.url = postgresql://metnorth_test:PASSWORD@localhost:30112/metnorth_test?keepalives=1&keepalives_idle=300&keepalives_interval=300&keepalives_count=9
 
 [metnorth_prod]
-sqlalchemy.url = postgresql://metnorth@db.pcic.uvic.ca/metnorth
+sqlalchemy.url = postgresql://metnorth@db.pcic.uvic.ca/metnorth?keepalives=1&keepalives_idle=300&keepalives_interval=300&keepalives_count=9
 
-[crmp_test]
-sqlalchemy.url = postgresql://crmp@dbtest01.pcic.uvic.ca/crmp
+[crmp_dbtest01]
+sqlalchemy.url = postgresql://crmp@dbtest01.pcic.uvic.ca/crmp?keepalives=1&keepalives_idle=300&keepalives_interval=300&keepalives_count=9
+
+[crmp_dbtest02_hx]
+sqlalchemy.url = postgresql://crmp@dbtest02.pcic.uvic.ca:5432/crmp_hx?keepalives=1&keepalives_idle=300&keepalives_interval=300&keepalives_count=9
 
 [crmp_prod]
-sqlalchemy.url = postgresql://crmp@db.pcic.uvic.ca/crmp
+sqlalchemy.url = postgresql://crmp@db.pcic.uvic.ca/crmp?keepalives=1&keepalives_idle=300&keepalives_interval=300&keepalives_count=9
 
 ;[test]
 ;sqlalchemy.url = ...

--- a/pycds/alembic/change_history_utils.py
+++ b/pycds/alembic/change_history_utils.py
@@ -123,6 +123,36 @@ def populate_history_table(collection_name: str, pri_id_name: str):
     )
 
 
+def update_obs_raw_history_FKs():
+    """
+    Update the history FKs in obs_raw, in bulk.
+
+    This method would be easy to generalize to other tables with different FK
+    collections, but at the time of writing, only obs_raw needs bulk FK updates, and we
+    already have the query in hand.
+    """
+    # TODO: Rewrite as SA query?
+    op.execute(
+        """
+        WITH v as (
+            SELECT vars_id, max(meta_vars_hx_id) latest
+            FROM meta_vars_hx
+            GROUP BY vars_id
+        ),
+        h as (
+            SELECT history_id, max(meta_history_hx_id) latest
+            FROM meta_history_hx
+            GROUP BY history_id
+        )
+        UPDATE obs_raw_hx o
+        SET meta_vars_hx_id = v.latest, meta_history_hx_id = h.latest
+        FROM v, h
+        WHERE o.vars_id = v.vars_id
+        AND o.history_id = h.history_id        
+        """
+    )
+
+
 def create_primary_table_triggers(collection_name: str, prefix: str = "t100_"):
     # Trigger: Enforce mod_time and mod_user values on primary table.
     op.execute(

--- a/pycds/alembic/versions/8c05da87cb79_add_hx_tkg_to_obs_raw.py
+++ b/pycds/alembic/versions/8c05da87cb79_add_hx_tkg_to_obs_raw.py
@@ -20,7 +20,8 @@ from pycds.alembic.change_history_utils import (
     create_primary_table_triggers,
     create_history_table_indexes,
     hx_table_name,
-    update_obs_raw_history_FKs, pri_table_name,
+    update_obs_raw_history_FKs,
+    pri_table_name,
 )
 from pycds.alembic.util import grant_standard_table_privileges
 
@@ -42,6 +43,8 @@ foreign_keys = [("meta_history", "history_id"), ("meta_vars", "vars_id")]
 def upgrade():
     # Set the search_path so that when the history table is populated, the trigger
     # functions fired can find the functions that they call.
+    # Note: This is no longer relied upon, but it may be again in future, so leave
+    # this here.
     op.get_bind().execute(f"SET search_path TO {schema_name}, public")
 
     # Primary table
@@ -55,7 +58,9 @@ def upgrade():
         ),
     )
     # Existing trigger on obs_raw is superseded by the hx tracking trigger.
-    op.execute(f"DROP TRIGGER update_mod_time ON {pri_table_name(table_name)}")
+    op.execute(
+        f"DROP TRIGGER IF EXISTS update_mod_time ON {pri_table_name(table_name)}"
+    )
     create_primary_table_triggers(table_name)
 
     # History table

--- a/pycds/alembic/versions/8c05da87cb79_add_hx_tkg_to_obs_raw.py
+++ b/pycds/alembic/versions/8c05da87cb79_add_hx_tkg_to_obs_raw.py
@@ -55,7 +55,6 @@ def upgrade():
 
     # History table
     create_history_table(table_name, foreign_keys)
-    create_history_table_indexes(table_name, primary_key_name, foreign_keys)
 
     # Drop existing trigger on obs_raw; it is superseded by the hx tracking trigger.
     op.execute(f"DROP TRIGGER IF EXISTS update_mod_time ON {hx_table_name(table_name)}")
@@ -63,6 +62,7 @@ def upgrade():
     create_history_table_triggers(table_name, foreign_keys)
 
     populate_history_table(table_name, primary_key_name)
+    create_history_table_indexes(table_name, primary_key_name, foreign_keys)
     grant_standard_table_privileges(table_name, schema=schema_name)
 
 

--- a/tests/alembic_migrations/helpers.py
+++ b/tests/alembic_migrations/helpers.py
@@ -285,6 +285,7 @@ def check_history_tracking(
         ("delete", do_delete, delete_info),
     ):
         hx_count_pre = table_count(sesh, history_table)
+        # Perform the test operation
         op()
         sesh.flush()
         # Check that a new history record was inserted

--- a/tests/alembic_migrations/versions/v_8c05da87cb79_add_hx_tkg_to_obs_raw/test_on_real_tables/test_on_real_tables.py
+++ b/tests/alembic_migrations/versions/v_8c05da87cb79_add_hx_tkg_to_obs_raw/test_on_real_tables/test_on_real_tables.py
@@ -17,10 +17,11 @@ from pycds import (
 )
 from pycds.alembic.change_history_utils import hx_id_name
 from pycds.database import check_migration_version, get_schema_item_names
-from pycds.orm.tables import ObsHistory
+from pycds.orm.tables import ObsHistory, HistoryHistory, VariableHistory
 from tests.alembic_migrations.helpers import (
     check_history_table_initial_contents,
     check_history_tracking,
+    check_history_table_FKs,
 )
 
 logging.getLogger("sqlalchemy.engine").setLevel(logging.CRITICAL)
@@ -53,7 +54,7 @@ logging.getLogger("sqlalchemy.engine").setLevel(logging.CRITICAL)
             ObsHistory,
             "obs_raw_id",
             ("time", "datum", "vars_id", "history_id"),
-            (History, Variable),
+            ((History, HistoryHistory), (Variable, VariableHistory)),
             {
                 "values": {
                     "time": datetime.datetime(2100, 1, 1),
@@ -147,6 +148,10 @@ def test_table_contents(
         foreign_tables,
         schema_name,
     )
+
+    for foreign_base, foreign_history in foreign_tables:
+        check_history_table_FKs(sesh, primary, history, foreign_base, foreign_history)
+
     check_history_tracking(
         sesh,
         primary,

--- a/tests/alembic_migrations/versions/v_a59d64cf16ca_add_hx_tkg_to_main_metadata_tables/test_on_real_tables/test_on_real_tables.py
+++ b/tests/alembic_migrations/versions/v_a59d64cf16ca_add_hx_tkg_to_main_metadata_tables/test_on_real_tables/test_on_real_tables.py
@@ -87,7 +87,7 @@ schema_name = get_schema_name()
             StationHistory,
             "station_id",
             ("native_id", "network_id", "publish"),
-            (Network,),
+            ((Network, NetworkHistory),),
             {
                 "values": {
                     "native_id": "WOWZA",
@@ -129,7 +129,7 @@ schema_name = get_schema_name()
             HistoryHistory,
             "history_id",
             ("station_id", "station_name", "lon", "lat", "elevation"),
-            (Station,),
+            ((Station, StationHistory),),
             {
                 "values": {
                     "station_id": 4137,
@@ -184,7 +184,7 @@ schema_name = get_schema_name()
             VariableHistory,
             "vars_id",
             ("network_id", "name", "unit", "standard_name", "cell_method"),
-            (Network,),
+            ((Network, NetworkHistory),),
             {
                 "values": {
                     "network_id": 1,


### PR DESCRIPTION
Resolves #235 

This PR:
- Changes the migration script to update the history FKs in bulk after populating the history table, and to add the hx FK trigger after that.
- Adds indexes to the history table after populating it, not before.
- Adds tests of the history FK values computed by the bulk query.
- Fixes a stupid error made in #234 .