### PR TITLE
Optimize matview refresh

### DIFF
--- a/.github/workflows/code-format-check.yml
+++ b/.github/workflows/code-format-check.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
 

--- a/.github/workflows/code-format-check.yml
+++ b/.github/workflows/code-format-check.yml
@@ -2,6 +2,8 @@ name: Code format check
 
 on: push
 
+permissions:
+  contents: read
 jobs:
   check:
 
@@ -9,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,16 +7,20 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+\.dev[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
 
+permissions:
+  contents: read
 jobs:
   publish:
 
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.12'
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -2,6 +2,8 @@ name: Python CI
 
 on: push
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-24.04
@@ -14,10 +16,12 @@ jobs:
           - "3.13"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -14,10 +14,10 @@ jobs:
           - "3.13"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/pycds/alembic/versions/f6d5a4c2e901_optimize_weather_anomaly_native_matviews.py
+++ b/pycds/alembic/versions/f6d5a4c2e901_optimize_weather_anomaly_native_matviews.py
@@ -1,0 +1,162 @@
+"""Optimize weather-anomaly native materialized views.
+
+Revision ID: f6d5a4c2e901
+Revises: 33179b5ae85a
+Create Date: 2026-06-24
+
+This migration:
+* adds a materialized view containing discarded observation IDs;
+* changes daily extrema and monthly precipitation to anti-join that helper;
+* marks effective_day immutable and parallel safe;
+* adds a (history_id, obs_time) index used by station_obs_stats_mv.
+
+The normal refresh job must refresh discarded_obs_raw_mv before its dependent
+weather-anomaly materialized views.
+"""
+
+from alembic import op
+
+from pycds import get_schema_name, get_su_role_name
+from pycds.alembic.util import create_matview, drop_matview
+from pycds.database import get_schema_item_names
+from pycds.orm.functions.version_f6d5a4c2e901 import effective_day
+from pycds.orm.functions.version_4a2f1879293a import (
+    effective_day as previous_effective_day,
+)
+from pycds.orm.native_matviews.version_f6d5a4c2e901 import (
+    DiscardedObsRaw,
+    DailyMaxTemperature,
+    DailyMinTemperature,
+    MonthlyTotalPrecipitation,
+    MonthlyAverageOfDailyMaxTemperature,
+    MonthlyAverageOfDailyMinTemperature,
+)
+from pycds.orm.native_matviews.version_081f17262852 import (
+    DailyMaxTemperature as PreviousDailyMaxTemperature,
+    DailyMinTemperature as PreviousDailyMinTemperature,
+    MonthlyTotalPrecipitation as PreviousMonthlyTotalPrecipitation,
+    MonthlyAverageOfDailyMaxTemperature as PreviousMonthlyAverageOfDailyMaxTemperature,
+    MonthlyAverageOfDailyMinTemperature as PreviousMonthlyAverageOfDailyMinTemperature,
+)
+
+
+revision = "f6d5a4c2e901"
+down_revision = "33179b5ae85a"
+branch_labels = None
+depends_on = None
+
+
+schema_name = get_schema_name()
+
+# Creation order expresses the new dependency graph. Drop in reverse order.
+updated_matviews = (
+    DiscardedObsRaw,
+    DailyMaxTemperature,
+    DailyMinTemperature,
+    MonthlyTotalPrecipitation,
+    MonthlyAverageOfDailyMaxTemperature,
+    MonthlyAverageOfDailyMinTemperature,
+)
+
+previous_matviews = (
+    PreviousDailyMaxTemperature,
+    PreviousDailyMinTemperature,
+    PreviousMonthlyTotalPrecipitation,
+    PreviousMonthlyAverageOfDailyMaxTemperature,
+    PreviousMonthlyAverageOfDailyMinTemperature,
+)
+
+index_name = "obs_raw_history_obs_time_idx"
+index_table_name = "obs_raw"
+index_columns = ("history_id", "obs_time")
+
+
+def _create_history_obs_time_index():
+    conn = op.get_bind()
+    existing_indexes = get_schema_item_names(
+        conn,
+        "indexes",
+        table_name=index_table_name,
+        schema_name=schema_name,
+    )
+
+    if index_name not in existing_indexes:
+        op.create_index(
+            index_name,
+            index_table_name,
+            index_columns,
+            unique=False,
+            schema=schema_name,
+        )
+
+
+def _drop_history_obs_time_index():
+    conn = op.get_bind()
+    existing_indexes = get_schema_item_names(
+        conn,
+        "indexes",
+        table_name=index_table_name,
+        schema_name=schema_name,
+    )
+
+    if index_name in existing_indexes:
+        op.drop_index(
+            index_name,
+            table_name=index_table_name,
+            schema=schema_name,
+        )
+
+
+existing_matviews = (
+    DailyMaxTemperature,
+    DailyMinTemperature,
+    MonthlyTotalPrecipitation,
+    MonthlyAverageOfDailyMaxTemperature,
+    MonthlyAverageOfDailyMinTemperature,
+)
+
+new_matviews = (
+    DiscardedObsRaw,
+    DailyMaxTemperature,
+    DailyMinTemperature,
+    MonthlyTotalPrecipitation,
+    MonthlyAverageOfDailyMaxTemperature,
+    MonthlyAverageOfDailyMinTemperature,
+)
+
+
+def upgrade():
+    op.set_role(get_su_role_name())
+
+    # This is a ReplaceableFunction with replace=True, so the repository's
+    # canonical function definition and the database definition stay aligned.
+    op.create_replaceable_object(effective_day)
+
+    for matview in reversed(existing_matviews):
+        drop_matview(matview, schema=schema_name)
+
+    for matview in new_matviews:
+        create_matview(matview, schema=schema_name)
+
+    _create_history_obs_time_index()
+
+    op.reset_role()
+
+
+def downgrade():
+    op.set_role(get_su_role_name())
+
+    for matview in reversed(new_matviews):
+        drop_matview(matview, schema=schema_name)
+
+    for matview in previous_matviews:
+        create_matview(matview, schema=schema_name)
+
+    # previous_effective_day has replace=False because it was originally used
+    # for first creation. Reuse its definition but enable replacement here.
+    previous_effective_day.replace = True
+    op.create_replaceable_object(previous_effective_day)
+
+    _drop_history_obs_time_index()
+
+    op.reset_role()

--- a/pycds/alembic/versions/f6d5a4c2e901_optimize_weather_anomaly_native_matviews.py
+++ b/pycds/alembic/versions/f6d5a4c2e901_optimize_weather_anomaly_native_matviews.py
@@ -48,9 +48,15 @@ depends_on = None
 
 schema_name = get_schema_name()
 
-# Creation order expresses the new dependency graph. Drop in reverse order.
-updated_matviews = (
-    DiscardedObsRaw,
+previous_matviews = (
+    PreviousDailyMaxTemperature,
+    PreviousDailyMinTemperature,
+    PreviousMonthlyTotalPrecipitation,
+    PreviousMonthlyAverageOfDailyMaxTemperature,
+    PreviousMonthlyAverageOfDailyMinTemperature,
+)
+
+existing_matviews = (
     DailyMaxTemperature,
     DailyMinTemperature,
     MonthlyTotalPrecipitation,
@@ -58,12 +64,13 @@ updated_matviews = (
     MonthlyAverageOfDailyMinTemperature,
 )
 
-previous_matviews = (
-    PreviousDailyMaxTemperature,
-    PreviousDailyMinTemperature,
-    PreviousMonthlyTotalPrecipitation,
-    PreviousMonthlyAverageOfDailyMaxTemperature,
-    PreviousMonthlyAverageOfDailyMinTemperature,
+new_matviews = (
+    DiscardedObsRaw,
+    DailyMaxTemperature,
+    DailyMinTemperature,
+    MonthlyTotalPrecipitation,
+    MonthlyAverageOfDailyMaxTemperature,
+    MonthlyAverageOfDailyMinTemperature,
 )
 
 index_name = "obs_raw_history_obs_time_idx"
@@ -105,24 +112,6 @@ def _drop_history_obs_time_index():
             table_name=index_table_name,
             schema=schema_name,
         )
-
-
-existing_matviews = (
-    DailyMaxTemperature,
-    DailyMinTemperature,
-    MonthlyTotalPrecipitation,
-    MonthlyAverageOfDailyMaxTemperature,
-    MonthlyAverageOfDailyMinTemperature,
-)
-
-new_matviews = (
-    DiscardedObsRaw,
-    DailyMaxTemperature,
-    DailyMinTemperature,
-    MonthlyTotalPrecipitation,
-    MonthlyAverageOfDailyMaxTemperature,
-    MonthlyAverageOfDailyMinTemperature,
-)
 
 
 def upgrade():

--- a/pycds/database.py
+++ b/pycds/database.py
@@ -10,7 +10,7 @@ from pycds.context import get_schema_name
 
 
 def check_migration_version(
-    executor, schema_name=get_schema_name(), version="33179b5ae85a"
+    executor, schema_name=get_schema_name(), version="f6d5a4c2e901"
 ):
     """Check that the migration version of the database schema is compatible
     with the current version of this package.

--- a/pycds/orm/functions/version_f6d5a4c2e901.py
+++ b/pycds/orm/functions/version_f6d5a4c2e901.py
@@ -1,0 +1,53 @@
+"""
+Function definitions introduced by migration f6d5a4c2e901.
+
+Only effective_day is changed in this version. Its implementation is retained;
+the function is declared immutable and parallel safe so PostgreSQL may run
+daily-extrema aggregation plans in parallel.
+"""
+
+from pycds.alembic.extensions.replaceable_objects import ReplaceableFunction
+from pycds.context import get_schema_name
+
+
+schema_name = get_schema_name()
+
+
+effective_day = ReplaceableFunction(
+    """
+    effective_day(
+        obs_time timestamp without time zone,
+        extremum character varying,
+        freq character varying DEFAULT ''::character varying
+    )
+    """,
+    """
+    RETURNS timestamp without time zone
+    AS $BODY$
+    DECLARE
+        offs INTERVAL;
+        hour INTEGER;
+    BEGIN
+        offs := '0'::INTERVAL;
+
+        IF extremum = 'max' THEN
+            hour := date_part('hour', obs_time);
+
+            IF freq = '12-hourly' AND hour >= 12 THEN
+                offs = '1 day'::INTERVAL;
+            END IF;
+        ELSE
+            offs = '0'::INTERVAL;
+        END IF;
+
+        RETURN date_trunc('day', obs_time) + offs;
+    END;
+    $BODY$
+    LANGUAGE plpgsql
+    IMMUTABLE
+    PARALLEL SAFE
+    COST 100;
+    """,
+    schema=schema_name,
+    replace=True,
+)

--- a/pycds/orm/native_matviews/__init__.py
+++ b/pycds/orm/native_matviews/__init__.py
@@ -31,6 +31,7 @@ from .version_081f17262852 import DailyMaxTemperature
 from .version_081f17262852 import DailyMinTemperature
 from .version_081f17262852 import MonthlyAverageOfDailyMaxTemperature
 from .version_081f17262852 import MonthlyAverageOfDailyMinTemperature
+from .version_f6d5a4c2e901 import DiscardedObsRaw
 
 # only used for tests
 from .version_081f17262852 import daily_temperature_extremum

--- a/pycds/orm/native_matviews/__init__.py
+++ b/pycds/orm/native_matviews/__init__.py
@@ -26,21 +26,21 @@ from .version_96729d6db8b3 import ClimoObsCount
 from .version_bf366199f463 import StationObservationStats
 from .version_fecff1a73d7e import CollapsedVariables
 from .version_bb2a222a1d4a import ObsCountPerMonthHistory
-from .version_081f17262852 import MonthlyTotalPrecipitation
-from .version_081f17262852 import DailyMaxTemperature
-from .version_081f17262852 import DailyMinTemperature
-from .version_081f17262852 import MonthlyAverageOfDailyMaxTemperature
-from .version_081f17262852 import MonthlyAverageOfDailyMinTemperature
+from .version_f6d5a4c2e901 import MonthlyTotalPrecipitation
+from .version_f6d5a4c2e901 import DailyMaxTemperature
+from .version_f6d5a4c2e901 import DailyMinTemperature
+from .version_f6d5a4c2e901 import MonthlyAverageOfDailyMaxTemperature
+from .version_f6d5a4c2e901 import MonthlyAverageOfDailyMinTemperature
 from .version_f6d5a4c2e901 import DiscardedObsRaw
 
 # only used for tests
-from .version_081f17262852 import daily_temperature_extremum
-from .version_081f17262852 import (
+from .version_f6d5a4c2e901 import daily_temperature_extremum
+from .version_f6d5a4c2e901 import (
     monthly_average_of_daily_temperature_extremum_with_avg_coverage,
 )
-from .version_081f17262852 import (
+from .version_f6d5a4c2e901 import (
     monthly_average_of_daily_temperature_extremum_with_total_coverage,
 )
-from .version_081f17262852 import monthly_total_precipitation_with_avg_coverage
-from .version_081f17262852 import monthly_total_precipitation_with_total_coverage
-from .version_081f17262852 import good_obs
+from .version_f6d5a4c2e901 import monthly_total_precipitation_with_avg_coverage
+from .version_f6d5a4c2e901 import monthly_total_precipitation_with_total_coverage
+from .version_f6d5a4c2e901 import good_obs

--- a/pycds/orm/native_matviews/version_f6d5a4c2e901.py
+++ b/pycds/orm/native_matviews/version_f6d5a4c2e901.py
@@ -1,0 +1,348 @@
+"""
+Native matviews for weather-anomaly application, optimized to reuse a
+materialized set of discarded observation IDs.
+
+This version retains the established weather-anomaly semantics:
+observations with any native or PCIC flag whose ``discard`` field is true are
+excluded. The difference is that discard status is computed once in
+``discarded_obs_raw_mv`` and consumed through an anti-join by the three
+dependent views.
+"""
+
+from sqlalchemy import (
+    func,
+    and_,
+    or_,
+    not_,
+    case,
+    cast,
+    Column,
+    BigInteger,
+    Integer,
+    String,
+    Date,
+    DateTime,
+    Float,
+    Index,
+)
+from sqlalchemy.orm import Query
+
+from pycds.context import get_schema_name
+from pycds.orm.tables import (
+    History,
+    Obs,
+    ObsRawNativeFlags,
+    NativeFlag,
+    ObsRawPCICFlags,
+    PCICFlag,
+    Variable,
+)
+from pycds.alembic.extensions.replaceable_objects import ReplaceableNativeMatview
+from pycds.orm.view_base import make_declarative_base
+
+
+Base = make_declarative_base()
+
+
+# Build this from the same relationship-driven joins used by the existing
+# good_obs definition. Do not refer directly to association-table columns
+# here: historical ORM mapping details are intentionally hidden behind these
+# relationships.
+
+discarded_obs_raw = (
+    Query(
+        [
+            Obs.id.label("obs_raw_id"),
+        ]
+    )
+    .select_from(Obs)
+    .outerjoin(ObsRawNativeFlags)
+    .outerjoin(NativeFlag)
+    .outerjoin(ObsRawPCICFlags)
+    .outerjoin(PCICFlag)
+    .group_by(Obs.id)
+    .having(
+        or_(
+            func.bool_or(func.coalesce(NativeFlag.discard, False)),
+            func.bool_or(func.coalesce(PCICFlag.discard, False)),
+        )
+    )
+)
+
+
+class DiscardedObsRaw(Base, ReplaceableNativeMatview):
+    __tablename__ = "discarded_obs_raw_mv"
+
+    # The Python attribute is ``id``; the physical materialized-view column
+    # remains ``obs_raw_id`` to match the source identifier.
+    id = Column("obs_raw_id", BigInteger, primary_key=True)
+
+    __selectable__ = discarded_obs_raw.selectable
+
+
+Index(
+    "discarded_obs_raw_mv_pkey",
+    DiscardedObsRaw.id,
+    unique=True,
+)
+
+
+# Shared source for daily temperature extrema and monthly total precipitation.
+# Keep observations absent from the discarded-ID materialized view.
+good_obs = (
+    Query(
+        [
+            Obs.id.label("id"),
+            Obs.time.label("time"),
+            Obs.mod_time.label("mod_time"),
+            Obs.datum.label("datum"),
+            Obs.vars_id.label("vars_id"),
+            Obs.history_id.label("history_id"),
+        ]
+    )
+    .select_from(Obs)
+    .outerjoin(DiscardedObsRaw, Obs.id == DiscardedObsRaw.id)
+    .filter(DiscardedObsRaw.id.is_(None))
+).subquery("good_obs")
+
+
+def monthly_total_precipitation_with_total_coverage():
+    return (
+        Query(
+            [
+                History.id.label("history_id"),
+                good_obs.c.vars_id.label("vars_id"),
+                func.date_trunc("month", good_obs.c.time).label("obs_month"),
+                func.sum(good_obs.c.datum).label("statistic"),
+                func.sum(
+                    case(
+                        {
+                            "daily": 1.0,
+                            "12-hourly": 0.5,
+                            "1-hourly": 1 / 24,
+                        },
+                        value=History.freq,
+                    )
+                ).label("total_data_coverage"),
+            ]
+        )
+        .select_from(good_obs)
+        .join(History)
+        .join(Variable)
+        .filter(
+            Variable.standard_name.in_(
+                (
+                    "lwe_thickness_of_precipitation_amount",
+                    "thickness_of_rainfall_amount",
+                    "thickness_of_snowfall_amount",
+                )
+            )
+        )
+        .filter(Variable.cell_method == "time: sum")
+        .filter(not_(Variable.name == "cum_pcpn_amt"))
+        .filter(History.freq.in_(("1-hourly", "daily")))
+        .group_by(History.id, good_obs.c.vars_id, "obs_month")
+    )
+
+
+def monthly_total_precipitation_with_avg_coverage():
+    monthly_total_precip = monthly_total_precipitation_with_total_coverage().subquery(
+        "monthly_total_precip"
+    )
+    func_schema = getattr(func, get_schema_name())
+
+    return Query(
+        [
+            monthly_total_precip.c.history_id.label("history_id"),
+            monthly_total_precip.c.vars_id.label("vars_id"),
+            monthly_total_precip.c.obs_month.label("obs_month"),
+            monthly_total_precip.c.statistic.label("statistic"),
+            (
+                monthly_total_precip.c.total_data_coverage
+                / func_schema.DaysInMonth(cast(monthly_total_precip.c.obs_month, Date))
+            ).label("data_coverage"),
+        ]
+    ).select_from(monthly_total_precip)
+
+
+class MonthlyTotalPrecipitation(Base, ReplaceableNativeMatview):
+    __tablename__ = "monthly_total_precipitation_mv"
+
+    history_id = Column(Integer, primary_key=True)
+    vars_id = Column(Integer, primary_key=True)
+    obs_month = Column(DateTime, primary_key=True)
+    statistic = Column(Float)
+    data_coverage = Column(Float)
+
+    __selectable__ = monthly_total_precipitation_with_avg_coverage().selectable
+
+
+def daily_temperature_extremum(extremum):
+    extremum_func = getattr(func, extremum)
+    func_schema = getattr(func, get_schema_name())
+
+    return (
+        Query(
+            [
+                History.id.label("history_id"),
+                good_obs.c.vars_id.label("vars_id"),
+                func_schema.effective_day(
+                    good_obs.c.time,
+                    cast(extremum, String),
+                    cast(History.freq, String),
+                ).label("obs_day"),
+                extremum_func(good_obs.c.datum).label("statistic"),
+                func.sum(
+                    case(
+                        {
+                            "daily": 1.0,
+                            "12-hourly": 0.5,
+                            "1-hourly": 1 / 24,
+                        },
+                        value=History.freq,
+                    )
+                ).label("data_coverage"),
+            ]
+        )
+        .select_from(good_obs)
+        .join(Variable)
+        .join(History)
+        .filter(Variable.standard_name == "air_temperature")
+        .filter(
+            Variable.cell_method.in_(
+                (
+                    f"time: {extremum}imum",
+                    "time: point",
+                    "time: mean",
+                )
+            )
+        )
+        .filter(History.freq.in_(("1-hourly", "12-hourly", "daily")))
+        .group_by(History.id, good_obs.c.vars_id, "obs_day")
+    )
+
+
+class DailyMaxTemperature(Base, ReplaceableNativeMatview):
+    __tablename__ = "daily_max_temperature_mv"
+
+    history_id = Column(Integer, primary_key=True)
+    vars_id = Column(Integer, primary_key=True)
+    obs_day = Column(DateTime, primary_key=True)
+    statistic = Column(Float)
+    data_coverage = Column(Float)
+
+    __selectable__ = daily_temperature_extremum("max").selectable
+
+
+class DailyMinTemperature(Base, ReplaceableNativeMatview):
+    __tablename__ = "daily_min_temperature_mv"
+
+    history_id = Column(Integer, primary_key=True)
+    vars_id = Column(Integer, primary_key=True)
+    obs_day = Column(DateTime, primary_key=True)
+    statistic = Column(Float)
+    data_coverage = Column(Float)
+
+    __selectable__ = daily_temperature_extremum("min").selectable
+
+
+def monthly_average_of_daily_temperature_extremum_with_total_coverage(
+    extremum,
+):
+    daily_extreme = DailyMaxTemperature if extremum == "max" else DailyMinTemperature
+    obs_month = func.date_trunc("month", daily_extreme.obs_day)
+
+    return (
+        Query(
+            [
+                daily_extreme.history_id.label("history_id"),
+                daily_extreme.vars_id.label("vars_id"),
+                obs_month.label("obs_month"),
+                func.avg(daily_extreme.statistic).label("statistic"),
+                func.sum(daily_extreme.data_coverage).label("total_data_coverage"),
+            ]
+        )
+        .select_from(daily_extreme)
+        .group_by(daily_extreme.history_id, daily_extreme.vars_id, "obs_month")
+    )
+
+
+def monthly_average_of_daily_temperature_extremum_with_avg_coverage(
+    extremum,
+):
+    avg_daily_extreme_temperature = (
+        monthly_average_of_daily_temperature_extremum_with_total_coverage(
+            extremum
+        ).subquery("avg_daily_extreme_temperature")
+    )
+    func_schema = getattr(func, get_schema_name())
+
+    return Query(
+        [
+            avg_daily_extreme_temperature.c.history_id.label("history_id"),
+            avg_daily_extreme_temperature.c.vars_id.label("vars_id"),
+            avg_daily_extreme_temperature.c.obs_month.label("obs_month"),
+            avg_daily_extreme_temperature.c.statistic.label("statistic"),
+            (
+                avg_daily_extreme_temperature.c.total_data_coverage
+                / func_schema.DaysInMonth(
+                    cast(avg_daily_extreme_temperature.c.obs_month, Date)
+                )
+            ).label("data_coverage"),
+        ]
+    ).select_from(avg_daily_extreme_temperature)
+
+
+class MonthlyAverageOfDailyMaxTemperature(Base, ReplaceableNativeMatview):
+    __tablename__ = "monthly_average_of_daily_max_temperature_mv"
+
+    history_id = Column(Integer, primary_key=True)
+    vars_id = Column(Integer, primary_key=True)
+    obs_month = Column(DateTime, primary_key=True)
+    statistic = Column(Float)
+    data_coverage = Column(Float)
+
+    __selectable__ = monthly_average_of_daily_temperature_extremum_with_avg_coverage(
+        "max"
+    ).selectable
+
+
+class MonthlyAverageOfDailyMinTemperature(Base, ReplaceableNativeMatview):
+    __tablename__ = "monthly_average_of_daily_min_temperature_mv"
+
+    history_id = Column(Integer, primary_key=True)
+    vars_id = Column(Integer, primary_key=True)
+    obs_month = Column(DateTime, primary_key=True)
+    statistic = Column(Float)
+    data_coverage = Column(Float)
+
+    __selectable__ = monthly_average_of_daily_temperature_extremum_with_avg_coverage(
+        "min"
+    ).selectable
+
+
+Index(
+    "monthly_total_precipitation_mv_idx",
+    MonthlyTotalPrecipitation.history_id,
+    MonthlyTotalPrecipitation.vars_id,
+)
+Index(
+    "daily_max_temperature_mv_idx",
+    DailyMaxTemperature.history_id,
+    DailyMaxTemperature.vars_id,
+)
+Index(
+    "daily_min_temperature_mv_idx",
+    DailyMinTemperature.history_id,
+    DailyMinTemperature.vars_id,
+)
+Index(
+    "monthly_average_of_daily_max_temperature_mv_idx",
+    MonthlyAverageOfDailyMaxTemperature.history_id,
+    MonthlyAverageOfDailyMaxTemperature.vars_id,
+)
+Index(
+    "monthly_average_of_daily_min_temperature_mv_idx",
+    MonthlyAverageOfDailyMinTemperature.history_id,
+    MonthlyAverageOfDailyMinTemperature.vars_id,
+)

--- a/pycds/orm/native_matviews/version_f6d5a4c2e901.py
+++ b/pycds/orm/native_matviews/version_f6d5a4c2e901.py
@@ -11,7 +11,6 @@ dependent views.
 
 from sqlalchemy import (
     func,
-    and_,
     or_,
     not_,
     case,
@@ -325,24 +324,34 @@ Index(
     "monthly_total_precipitation_mv_idx",
     MonthlyTotalPrecipitation.history_id,
     MonthlyTotalPrecipitation.vars_id,
+    MonthlyTotalPrecipitation.obs_month,
+    unique=True,
 )
 Index(
     "daily_max_temperature_mv_idx",
     DailyMaxTemperature.history_id,
     DailyMaxTemperature.vars_id,
+    DailyMaxTemperature.obs_day,
+    unique=True,
 )
 Index(
     "daily_min_temperature_mv_idx",
     DailyMinTemperature.history_id,
     DailyMinTemperature.vars_id,
+    DailyMinTemperature.obs_day,
+    unique=True,
 )
 Index(
     "monthly_average_of_daily_max_temperature_mv_idx",
     MonthlyAverageOfDailyMaxTemperature.history_id,
     MonthlyAverageOfDailyMaxTemperature.vars_id,
+    MonthlyAverageOfDailyMaxTemperature.obs_month,
+    unique=True,
 )
 Index(
     "monthly_average_of_daily_min_temperature_mv_idx",
     MonthlyAverageOfDailyMinTemperature.history_id,
     MonthlyAverageOfDailyMinTemperature.vars_id,
+    MonthlyAverageOfDailyMinTemperature.obs_month,
+    unique=True,
 )

--- a/tests/alembic_migrations/test_check_migration_version.py
+++ b/tests/alembic_migrations/test_check_migration_version.py
@@ -8,7 +8,7 @@ from pycds.database import check_migration_version
 
 @pytest.mark.update20
 def test_get_current_head():
-    assert get_current_head() == "33179b5ae85a"
+    assert get_current_head() == "f6d5a4c2e901"
 
 
 @pytest.mark.update20

--- a/tests/behavioural/native_matviews/weather_anomaly/details/conftest.py
+++ b/tests/behavioural/native_matviews/weather_anomaly/details/conftest.py
@@ -1,6 +1,7 @@
 from pytest import fixture
 
 from pycds.orm.native_matviews import (
+    DiscardedObsRaw,
     MonthlyTotalPrecipitation,
     DailyMaxTemperature,
     DailyMinTemperature,
@@ -17,7 +18,7 @@ def autouse_new_db_left(new_db_left):
 
 @fixture
 def daily_views():
-    return [DailyMaxTemperature, DailyMinTemperature]
+    return [DiscardedObsRaw, DailyMaxTemperature, DailyMinTemperature]
 
 
 @fixture


### PR DESCRIPTION
# PyCDS materialized-view refresh performance review

- 2026-06-25
- Final-ish test-database results after applying Alembic revision to pg01.pcic.uvic.ca/crmp
`f6d5a4c2e901` and running the normal refresh script.

## Summary

The ORM/Alembic migration produced the expected improvement.

- Full refresh suite: **1:24:20.47 → 21:01.40**
- Net reduction: **1:03:19.07 (75.1% faster)**, including the new observation discard-helper refresh.
- Excluding the helper, the pre-existing views completed in **15:25.90**, a **81.7%** reduction.
- The three formerly dominant weather-anomaly views fell from **1:15:29.43** to **10:34.21**, a **86.0%** reduction.
- The new `discarded_obs_raw_mv` helper costs **5:35.50** per run (on crmp), but its reuse more than offsets that cost downstream.

## Final refresh timings

The run used session settings:

```sql
SET work_mem = '256MB';
SET max_parallel_workers_per_gather = 4;
```

| Materialized view | Initial benchmark | Final migration-run refresh | Change |
|---|---:|---:|---:|
| `discarded_obs_raw_mv` | — | 5:35.50 | New prerequisite |
| `station_obs_stats_mv` | 2:53.71 | 1:47.02 | 38.4% faster |
| `vars_per_history_mv` | 1:55.86 | 1:13.08 | 36.9% faster |
| `obs_count_per_month_history_mv` | 3:25.48 | 1:21.00 | 60.6% faster |
| `climo_obs_count_mv` | 0:00.06 | 0:00.13 | negligible |
| `collapsed_vars_mv` | 0:00.23 | 0:00.24 | negligible |
| `monthly_total_precipitation_mv` | 22:14.44 | 3:48.13 | 82.9% faster |
| `daily_max_temperature_mv` | 26:47.60 | 3:23.65 | 87.3% faster |
| `daily_min_temperature_mv` | 26:27.39 | 3:22.43 | 87.2% faster |
| `monthly_average_of_daily_max_temperature_mv` | 0:17.90 | 0:15.38 | 14.1% faster |
| `monthly_average_of_daily_min_temperature_mv` | 0:17.79 | 0:14.84 | 16.6% faster |

## Interpretation

### Weather-anomaly materialized views

The migration replaces repeated per-view flag expansion/grouping with one reusable
`discarded_obs_raw_mv`, then anti-joins that helper from the daily extrema and
monthly precipitation views.

- `monthly_total_precipitation_mv`: **22:14.44 → 3:48.13** (82.9% faster)
- `daily_max_temperature_mv`: **26:47.60 → 3:23.65** (87.3% faster)
- `daily_min_temperature_mv`: **26:27.39 → 3:22.43** (87.2% faster)

The behavioural test correction confirms the operational requirement: refresh
`discarded_obs_raw_mv` before the dependent views, or they can consume a stale
discard set.

### Station observation statistics

The new `obs_raw(history_id, obs_time)` index improved
`station_obs_stats_mv` from **2:53.71** to
**1:47.02**
(38.4% faster).

`vars_per_history_mv` and `obs_count_per_month_history_mv` also improved in
this run. Those gains may include cache state and background-workload variation,
so they should not be attributed solely to the migration without repeat runs.

## Required refresh order

1. `discarded_obs_raw_mv`
2. `station_obs_stats_mv`
3. `vars_per_history_mv`
4. `obs_count_per_month_history_mv`
5. `climo_obs_count_mv`
6. `collapsed_vars_mv`
7. `monthly_total_precipitation_mv`
8. `daily_max_temperature_mv`
9. `daily_min_temperature_mv`
10. `monthly_average_of_daily_max_temperature_mv`
11. `monthly_average_of_daily_min_temperature_mv`

The essential dependency is that `discarded_obs_raw_mv` must be refreshed
before daily max, daily min, and monthly precipitation. The monthly-average
views must follow their corresponding daily extrema.

## Caveats

- Earlier and final timings were collected in separate runs; cache state and
  concurrent activity can affect individual views.
- The full-suite comparison includes the helper, which is the correct
  operational comparison.
- These timings measure the normal post-migration refresh workflow, not the
  one-time cost of running the Alembic migration, which recreates views.
- The session settings should be applied to the dedicated refresh session only,
  after confirming memory and concurrency headroom.

## Follow-up

After review of the PR, if we wanted to be ultra-conservative, we
could apply the Alembic migration to a test database and run our
webapps and crmprtd against it for a few days. I think that the patch
is well tested, and there's little risk to applying it in prod, but
I'm also happy to hear other considerations.
