### PR TITLE
Rewrites the query_one_station function to use ORM

### DIFF
--- a/pycds/data/query_one_station_fixture_data.sql
+++ b/pycds/data/query_one_station_fixture_data.sql
@@ -1,0 +1,96 @@
+-- Minimal fixture for ORM query_one_station tests.
+--
+-- The target station/history and its temperature observations are copied from
+-- crmp_subset_data.sql. Precipitation and wind speed are actual variables in
+-- the same network, but are observed only at a synthetic peer station.
+
+INSERT INTO meta_network (
+    network_id,
+    network_name,
+    description,
+    virtual,
+    publish,
+    col_hex,
+    contact_id
+) VALUES (
+    12,
+    'FLNRO-WMB',
+    'BC Ministry of Forests, Lands, and Natural Resource Operations - Wild Fire Management Branch',
+    NULL,
+    true,
+    '#0C6600',
+    NULL
+);
+
+INSERT INTO meta_station (
+    station_id,
+    network_id,
+    native_id,
+    min_obs_time,
+    max_obs_time,
+    publish
+) VALUES
+    (2313, 12, '932', '2006-02-10 15:00:00', '2006-02-12 12:00:00', true),
+    (2314, 12, 'query-one-station-peer', '2006-02-10 15:00:00', '2006-02-10 18:00:00', true),
+    (2315, 12, 'query-one-station-empty', '2006-02-10 15:00:00', '2006-02-10 15:00:00', true);
+
+INSERT INTO meta_history (
+    history_id,
+    station_id,
+    station_name,
+    lon,
+    lat,
+    elev,
+    sdate,
+    edate,
+    tz_offset,
+    province,
+    country,
+    comments,
+    the_geom,
+    sensor_id,
+    freq
+) VALUES
+    (2716, 2313, 'ZZ GYPSY 2', -124.0147, 49.2283, 156, NULL, NULL, NULL, 'BC', NULL, NULL, NULL, NULL, '1-hourly'),
+    (2717, 2314, 'QUERY ONE STATION PEER', -124.0147, 49.2283, 156, NULL, NULL, NULL, 'BC', NULL, NULL, NULL, NULL, '1-hourly'),
+    (2718, 2315, 'QUERY ONE STATION EMPTY', -124.0147, 49.2283, 156, NULL, NULL, NULL, 'BC', NULL, NULL, NULL, NULL, '1-hourly');
+
+INSERT INTO meta_vars (
+    vars_id,
+    network_id,
+    unit,
+    "precision",
+    standard_name,
+    cell_method,
+    long_description,
+    net_var_name,
+    display_name,
+    short_name
+) VALUES
+    (496, 12, 'mm', NULL, 'lwe_thickness_of_precipitation_amount', 'time: sum', 'depth of water-equivalent rain', 'precipitation', 'Precipitation Amount', 'lwe_thickness_of_precipitation_amount_sum'),
+    (497, 12, 'celsius', NULL, 'air_temperature', 'time: point', NULL, 'temperature', 'Temperature (Point)', 'air_temperature_point'),
+    (498, 12, 'celsius', NULL, 'air_temperature', 'time: mean within months time: mean over years', 'Climatological mean temperature', 'temperature_climatology', 'Temperature Climatology', 'air_temperature_climatology'),
+    (499, 12, 'm s-1', NULL, 'wind_speed', 'time: mean', NULL, 'wind_speed', 'Wind Speed (Mean)', 'wind_speed_mean');
+
+INSERT INTO obs_raw (
+    obs_raw_id,
+    obs_time,
+    mod_time,
+    datum,
+    vars_id,
+    history_id
+) VALUES
+    -- Production-derived target-station temperature observations.
+    (194852502, '2006-02-10 15:00:00', '2011-08-29 12:13:18.197183', 9.69999981, 497, 2716),
+    (194852505, '2006-02-10 18:00:00', '2011-08-29 12:13:18.197183', 4.80000019, 497, 2716),
+    (194852517, '2006-02-11 06:00:00', '2011-08-29 12:13:18.197183', 4.5999999, 497, 2716),
+    (194852547, '2006-02-12 12:00:00', '2011-08-29 12:13:18.197183', 9.19999981, 497, 2716),
+
+    -- Network variables observed at the peer station only.
+    (194852600, '2006-02-10 15:00:00', '2011-08-29 12:13:18.197183', 0.0, 496, 2717),
+    (194852601, '2006-02-10 15:00:00', '2011-08-29 12:13:18.197183', 2.5, 499, 2717),
+    (194852602, '2006-02-10 18:00:00', '2011-08-29 12:13:18.197183', 1.2, 496, 2717),
+    (194852603, '2006-02-10 18:00:00', '2011-08-29 12:13:18.197183', 3.1, 499, 2717),
+
+    -- Target-station climatological value for the climo=True branch.
+    (194852604, '2006-02-10 15:00:00', '2011-08-29 12:13:18.197183', 7.0, 498, 2716);

--- a/pycds/orm/station_queries.py
+++ b/pycds/orm/station_queries.py
@@ -1,0 +1,102 @@
+"""ORM queries for pivoted station-observation tables."""
+
+from sqlalchemy import case, false, func, select
+from sqlalchemy.orm import Session
+
+from pycds.orm.native_matviews import VarsPerHistory
+from pycds.orm.tables import History, Obs, Variable
+
+
+def _station_variables(
+    session: Session,
+    station_id: int,
+    climo: bool,
+) -> list[tuple[int, str]]:
+    """Return variables actually observed at a station, ordered by name."""
+    is_climatological = Variable.cell_method.op("~")(r"(within|over)")
+
+    statement = (
+        select(VarsPerHistory.vars_id, Variable.name)
+        .select_from(VarsPerHistory)
+        .join(History, History.id == VarsPerHistory.history_id)
+        .join(Variable, Variable.id == VarsPerHistory.vars_id)
+        .where(
+            History.station_id == station_id,
+            is_climatological if climo else ~is_climatological,
+        )
+        .distinct()
+        .order_by(Variable.name)
+    )
+
+    # The legacy SQL emits unquoted aliases, which PostgreSQL folds to lower
+    # case. Preserve that result-column convention.
+    return [
+        (vars_id, str(variable_name).lower())
+        for vars_id, variable_name in session.execute(statement)
+    ]
+
+
+def query_one_station(
+    session: Session,
+    station_id: int,
+    climo: bool = False,
+):
+    """
+    Build a pivoted observation query for one station.
+
+    The result has ``obs_time`` as its first column, followed by one column per
+    variable actually present at the station. Values from overlapping histories
+    retain the legacy ``max(datum)`` resolution rule.
+    """
+    variables = _station_variables(
+        session,
+        station_id,
+        climo=climo,
+    )
+
+    # Unlike the legacy function, an empty variable list is a valid request.
+    if not variables:
+        return select(Obs.time.label("obs_time")).where(false())
+
+    variable_ids = [vars_id for vars_id, _ in variables]
+
+    variable_columns = [
+        func.max(
+            case(
+                (Obs.vars_id == vars_id, Obs.datum),
+                else_=None,
+            )
+        ).label(variable_name)
+        for vars_id, variable_name in variables
+    ]
+
+    return (
+        select(
+            Obs.time.label("obs_time"),
+            *variable_columns,
+        )
+        .select_from(Obs)
+        .join(History, History.id == Obs.history_id)
+        .where(
+            History.station_id == station_id,
+            Obs.vars_id.in_(variable_ids),
+        )
+        .group_by(Obs.time)
+        .order_by(Obs.time)
+    )
+
+
+def do_query_one_station(
+    session: Session,
+    station_id: int,
+    *,
+    climo: bool = False,
+):
+    """Execute :func:`query_one_station`."""
+    return session.execute(
+        query_one_station(
+            session,
+            station_id,
+            climo=climo,
+        )
+    )

--- a/tests/behavioural/functions/test_station_queries.py
+++ b/tests/behavioural/functions/test_station_queries.py
@@ -1,0 +1,168 @@
+from datetime import datetime
+from importlib.resources import files
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.orm import Session
+
+from pycds import VarsPerHistory, get_schema_name, schema_func
+from pycds.orm.station_queries import do_query_one_station, query_one_station
+
+
+TARGET_STATION_ID = 2313
+TARGET_HISTORY_ID = 2716
+PEER_HISTORY_ID = 2717
+EMPTY_STATION_ID = 2315
+EMPTY_HISTORY_ID = 2718
+
+getstationvariabletable = schema_func.getstationvariabletable
+
+
+@pytest.fixture
+def sesh_with_query_one_station_data(
+    alembic_engine,
+    alembic_runner,
+    target_revision,
+    schema_name,
+):
+    """Provide a migrated session with focused query_one_station fixture data."""
+    alembic_runner.migrate_up_to(target_revision if target_revision else "head")
+
+    fixture_data = (
+        files("pycds").joinpath("data/query_one_station_fixture_data.sql").read_text()
+    )
+
+    with alembic_engine.begin() as conn:
+        conn.execute(text(f"SET search_path TO {schema_name}, public"))
+        conn.execute(text(fixture_data))
+
+    sesh = Session(alembic_engine)
+    sesh.execute(text(f"SET search_path TO {schema_name}, public"))
+
+    yield sesh
+
+    sesh.rollback()
+    sesh.close()
+
+
+@pytest.mark.usefixtures("new_db_left")
+def test_query_one_station_filters_station_variables_and_climatology(
+    sesh_with_query_one_station_data,
+):
+    """
+    Return only variables observed at the target station and requested kind.
+
+    The legacy function discovers variables at the network level, so it also
+    returns peer-station precipitation and wind-speed columns for this target.
+    """
+    sesh = sesh_with_query_one_station_data
+    sesh.execute(VarsPerHistory.refresh())
+
+    target_variable_ids = sesh.scalars(
+        select(VarsPerHistory.vars_id)
+        .where(VarsPerHistory.history_id == TARGET_HISTORY_ID)
+        .order_by(VarsPerHistory.vars_id)
+    ).all()
+    peer_variable_ids = sesh.scalars(
+        select(VarsPerHistory.vars_id)
+        .where(VarsPerHistory.history_id == PEER_HISTORY_ID)
+        .order_by(VarsPerHistory.vars_id)
+    ).all()
+
+    assert target_variable_ids == [497, 498]
+    assert peer_variable_ids == [496, 499]
+
+    legacy_query = sesh.query(
+        getstationvariabletable(TARGET_STATION_ID, False)
+    ).scalar()
+    legacy_column_names = list(sesh.execute(text(legacy_query)).keys())
+
+    # Characterize the defect being fixed: these variables are defined for the
+    # network and observed by the peer station, but not by the target station.
+    assert legacy_column_names == [
+        "obs_time",
+        "precipitation",
+        "temperature",
+        "wind_speed",
+    ]
+
+    observation_result = do_query_one_station(
+        sesh,
+        TARGET_STATION_ID,
+        climo=False,
+    )
+    assert list(observation_result.keys()) == ["obs_time", "temperature"]
+
+    observation_rows = observation_result.mappings().all()
+    assert [row["obs_time"] for row in observation_rows] == [
+        datetime(2006, 2, 10, 15),
+        datetime(2006, 2, 10, 18),
+        datetime(2006, 2, 11, 6),
+        datetime(2006, 2, 12, 12),
+    ]
+    assert [row["temperature"] for row in observation_rows] == pytest.approx(
+        [9.7, 4.8, 4.6, 9.2]
+    )
+
+    climo_result = do_query_one_station(
+        sesh,
+        TARGET_STATION_ID,
+        climo=True,
+    )
+    assert list(climo_result.keys()) == [
+        "obs_time",
+        "temperature_climatology",
+    ]
+
+    climo_rows = climo_result.mappings().all()
+    assert [row["obs_time"] for row in climo_rows] == [
+        datetime(2006, 2, 10, 15),
+    ]
+    assert [row["temperature_climatology"] for row in climo_rows] == (
+        pytest.approx([7.0])
+    )
+
+
+@pytest.mark.parametrize("climo", [False, True])
+def test_query_one_station_returns_empty_obs_time_table_when_no_variables(
+    sesh_with_query_one_station_data,
+    climo,
+):
+    """
+    An existing station with no observations yields a valid obs_time-only
+    result. The legacy function incorrectly exposes network-level variables.
+    """
+    sesh = sesh_with_query_one_station_data
+    sesh.execute(VarsPerHistory.refresh())
+
+    assert (
+        sesh.scalars(
+            select(VarsPerHistory.vars_id).where(
+                VarsPerHistory.history_id == EMPTY_HISTORY_ID
+            )
+        ).all()
+        == []
+    )
+
+    legacy_query = sesh.query(getstationvariabletable(EMPTY_STATION_ID, climo)).scalar()
+    legacy_result = sesh.execute(text(legacy_query))
+
+    legacy_column_names = list(legacy_result.keys())
+
+    # Peer stations have matching raw and climatological variables, so the
+    # legacy network-scoped discovery returns a misleading non-empty set of
+    # variable columns in both modes.
+    assert legacy_column_names[0] == "obs_time"
+    assert len(legacy_column_names) > 1
+    assert legacy_result.all() == []
+
+    orm_result = sesh.execute(
+        query_one_station(
+            sesh,
+            EMPTY_STATION_ID,
+            climo=climo,
+        )
+    )
+
+    assert list(orm_result.keys()) == ["obs_time"]
+    assert orm_result.all() == []


### PR DESCRIPTION
This patch adds an ORM-level function, `query_one_station()`, that provides the same functionality as a problematic PL/Python query with the same name

The legacy `query_one_station` and `do_query_one_station` function are written in fragile and hard to maintain PL/Python that were subsequently ported to the ORM afterward. They contain a number of shortcomings:

1: They build the variable list from the network-level, so it's common
   to return query results full of columns that *only* contain NAs for
   stations that don't record variables that other network peers do.
2: They don't utilize the `vars_per_history_mv` which records the actual
   variables that are recorded per history in the dataset
3: They have the potential to return bad SQL (and error out) if sent a
   query for a station with no observations
4: They use an in-database Python extension that is hard to maintain

About 3/4 of the code here is new tests and fixtures that demonstrate the old, problematic behviour and show the new behaviour.

I did some performance testing on the new vs. old. I don't have the full results available, but generally they provided a modest 10% speed up on 80% of the stations (10th-90th percentile of number of observations). The main benefits are more robust station queries.

This is the first step in replacing the ORM-level functions and this code does not change any existing functionality. But it will allow us to rewrite existing user-code (see: `pdp:pcds-only`, `met-data-portal-backend`) in a much cleaner and robust way.